### PR TITLE
KBV-64-add-change-postcode-link

### DIFF
--- a/src/app/address/controllers/addressResults.js
+++ b/src/app/address/controllers/addressResults.js
@@ -1,6 +1,13 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 
 class AddressResultsController extends BaseController {
+  locals(req, res, callback) {
+    super.locals(req, res, (err, locals) => {
+      locals.searchValue = req.sessionModel.get("searchValue");
+      callback(null, locals);
+    });
+  }
+
   saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       try {

--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -12,6 +12,7 @@ class AddressSearchController extends BaseController {
       const searchResults = await this.search(searchValue);
       super.saveValues(req, res, () => {
         req.sessionModel.set("searchResults", searchResults);
+        req.sessionModel.set("searchValue", searchValue);
         callback();
       });
     } catch (err) {

--- a/src/app/address/controllers/addressSearch.test.js
+++ b/src/app/address/controllers/addressSearch.test.js
@@ -64,6 +64,7 @@ describe("Address Search controller", () => {
     expect(axiosStub).to.have.been.calledWith(
       `${ORDNANCE_API_URL}postcode=${testPostcode}&key=${ORDNANCE_SURVEY_SECRET}`
     );
+    expect(req.session.test.searchValue).to.equal(testPostcode);
     expect(req.session.test.searchResults[0].buildingNumber).to.equal("1");
     expect(req.session.test.searchResults[0].streetName).to.equal("SOME ROAD");
     expect(req.session.test.searchResults[0].town).to.equal("SOMEWHERE");

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -11,4 +11,8 @@ govuk:
   error: Error
   warning: Warning
   skipLink: Skip to main content
+links:
+  changeAddress: <a href="address">Change</a>
+  changePostcode:
+    - <p>Postcode <br> <b>{{searchValue}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="search">Change</a></p>
 

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -18,3 +18,12 @@ address-results:
   content:
     - Postcode
     - <b>{{values.address-search}}</b> <a href="/postcode">Change</a>
+
+
+address-confirm:
+  title: Check your address details
+  warning:
+      - Make sure your details are correct before you continue. You won't be able to change it later.
+  current: Current address
+  previous: Previous address
+

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -7,14 +7,20 @@
 
 {% block content %}
   <h1>{{translate("pages.address-results.title")}}</h1>
+
   {% set hmpoTitleKey = "pages.address-results.title" %}
+
+  {{hmpoHtml(translate("links.changePostcode"))}}
+
   {% call hmpoForm(ctx) %}
     {{ hmpoSelect(ctx, {
       id: "address-selection",
       label: translate("fields.address-results.label"),
       items: values.searchResults
     }) }}
+
     {{ hmpoSubmit(ctx, {text: translate("buttons.select-address")}) }}
+
   {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

**NB please review: [KBV-172](https://github.com/alphagov/di-ipv-cri-address-front/pull/20)**  first

### What changed

Added a small UI change to display the searched postcode with a link to revert back a page and change their search query. A resulting test case for setting session variable was also added.

### Why did it change

To allow users to change their postcode after doing a search, we should add a change postcode link to directly back to the page they've come from. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-64](https://govukverify.atlassian.net/browse/KBV-64)

## Checklists

- [X] Screenshot of the change

### Images
![image](https://user-images.githubusercontent.com/8826525/152385594-d7b0f3f8-4b68-4116-b11a-541e2a26729a.png)
