### PR TITLE
KBV-186-add-validation-to-postcode-input

### DIFF
--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -22,5 +22,18 @@ module.exports = {
   "address-search": {
     type: "text",
     autocomplete: "Postcode",
+    validate: [
+      {
+        type: "required",
+      },
+      {
+        type: "minlength",
+        arguments: [5],
+      },
+      {
+        type: "maxlength",
+        arguments: [8],
+      },
+    ],
   },
 };

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -15,4 +15,9 @@ links:
   changeAddress: <a href="/address/edit">Change</a>
   changePostcode:
     - <p>Postcode <br> <b>{{searchValue}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/search">Change</a></p>
+validation:
+  required: Please enter a {{label}}.
+  maxlength: 'Maximum length of  the {{label}} should be 8'
+  minlength: 'Minimum length of the {{label}} should be 5'
+  default: You must answer this question.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add validation rules to postcode input and placeholder content for those errors for the time being.

### Why did it change

No validation on input currently.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-186](https://govukverify.atlassian.net/browse/KBV-186)

## Validation

### < 5 characters
<img width="375" alt="image" src="https://user-images.githubusercontent.com/8826525/153404329-1e06caf7-5645-4c77-b15f-1df2bae857d7.png">

### No data
<img width="378" alt="image" src="https://user-images.githubusercontent.com/8826525/153404391-51494b40-ad10-4532-ae78-d3ffffdf0eb7.png">

### > 8 characters
Handled by the form wizard

