### PR TITLE
KBV-171-add-address-not-found-link

### DIFF
--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -3,7 +3,7 @@ const BaseController = require("hmpo-form-wizard").Controller;
 class AddressController extends BaseController {
   locals(req, res, callback) {
     super.locals(req, res, (err, locals) => {
-      locals.addressPostcode =  req.sessionModel.get("addressPostcode");
+      locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addressLine1 = req.sessionModel.get("addressLine1");
       locals.addressLine2 = req.sessionModel.get("addressLine2");
       locals.addressTown = req.sessionModel.get("addressTown");
@@ -11,12 +11,13 @@ class AddressController extends BaseController {
     });
   }
 
-  async saveValues(req, res, next) {
-    req.sessionModel.set("addressLine1", req.body["addressLine1"]);
-    req.sessionModel.set("addressLine2", req.body["addressLine2"]);
-    req.sessionModel.set("addressTown", req.body["addressTown"]);
-
-    super.saveValues(req, res, next);
+  async saveValues(req, res, callback) {
+    super.saveValues(req, res, () => {
+      req.sessionModel.set("addressLine1", req.body["addressLine1"]);
+      req.sessionModel.set("addressLine2", req.body["addressLine2"]);
+      req.sessionModel.set("addressTown", req.body["addressTown"]);
+      callback();
+    });
   }
 }
 module.exports = AddressController;

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -25,10 +25,12 @@ module.exports = {
     controller: address,
     checkJourney: false,
     editable: true,
+    continueOnEdit: true,
     next: "confirm",
   },
   "/confirm": {
     controller: confirm,
+    prereqs: "/address/edit", // can enter confirm if coming from address edit
     next: "done",
   },
   // temporary display results

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -15,6 +15,8 @@ links:
   changeAddress: <a href="/address/edit">Change</a>
   changePostcode:
     - <p>Postcode <br> <b>{{addressPostcode}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/search">Change</a></p>
+  cantFindAddress:
+    - <p><a href="/address/edit">I cannot find my address in the list</a></p>
 validation:
   required: Please enter a {{label}}.
   maxlength: 'Maximum length of  the {{label}} should be 8'

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -13,11 +13,14 @@
   {{hmpoHtml(translate("links.changePostcode"))}}
 
   {% call hmpoForm(ctx) %}
+
     {{ hmpoSelect(ctx, {
       id: "address-selection",
       label: translate("fields.address-results.label"),
       items: values.searchResults
     }) }}
+
+    {{hmpoHtml(translate("links.cantFindAddress"))}}
 
     {{ hmpoSubmit(ctx, {text: translate("buttons.select-address")}) }}
 


### PR DESCRIPTION
## Proposed changes

We should allow users to enter their address manually in the event they are unable to find their address in the response.

### What changed

Added a hyperlink to the address view in the results view. Also modified the steps to allow the user to jump from the address to the confirmation page, permitting they had come from address.

### Why did it change

This change allows users to add their address manually when they cant find their address in the postcode response.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-171](https://govukverify.atlassian.net/browse/KBV-171)
<img width="978" alt="image" src="https://user-images.githubusercontent.com/8826525/154505717-e2253609-094d-4b28-bb41-e189913d4158.png">
