### PR TITLE
Kbv 201 handle error from postcode lookup

### DIFF
--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -6,6 +6,8 @@ const {
 
 class AddressSearchController extends BaseController {
   async saveValues(req, res, callback) {
+    const addressPostcode = req.body["address-search"];
+
     try {
       const addressPostcode = req.body["address-search"];
       const searchResults = await this.search(
@@ -13,12 +15,15 @@ class AddressSearchController extends BaseController {
         addressPostcode
       );
       super.saveValues(req, res, () => {
+        req.sessionModel.set("isSuccessful", true);
         req.sessionModel.set("searchResults", searchResults);
         req.sessionModel.set("addressPostcode", addressPostcode);
         callback();
       });
     } catch (err) {
-      callback(err);
+      req.sessionModel.set("isSuccessful", false);
+      req.sessionModel.set("addressPostcode", addressPostcode);
+      callback();
     }
   }
 

--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -15,13 +15,13 @@ class AddressSearchController extends BaseController {
         addressPostcode
       );
       super.saveValues(req, res, () => {
-        req.sessionModel.set("isSuccessful", true);
+        req.sessionModel.set("requestIsSuccessful", true);
         req.sessionModel.set("searchResults", searchResults);
         req.sessionModel.set("addressPostcode", addressPostcode);
         callback();
       });
     } catch (err) {
-      req.sessionModel.set("isSuccessful", false);
+      req.sessionModel.set("requestIsSuccessful", false);
       req.sessionModel.set("addressPostcode", addressPostcode);
       callback();
     }

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -16,8 +16,8 @@ module.exports = {
     fields: ["address-search"],
     next: [
       {
-        field: "isSuccessful",
-        op: (fieldValue, req, res, con) => fieldValue === con.value,
+        field: "requestIsSuccessful",
+        op: "===",
         value: true,
         next: "results",
       },

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -14,7 +14,15 @@ module.exports = {
   "/search": {
     controller: search,
     fields: ["address-search"],
-    next: "results",
+    next: [
+      {
+        field: "isSuccessful",
+        op: (fieldValue, req, res, con) => fieldValue === con.value,
+        value: true,
+        next: "results",
+      },
+      "address",
+    ],
   },
   "/results": {
     controller: results,

--- a/test/application/features/address.feature
+++ b/test/application/features/address.feature
@@ -1,13 +1,20 @@
 @mock-api:address-success @success
-Feature: Happy path
+Feature: Searching and adding an Address
   Viewing the Address lookup successfully
 
   Background:
     Given Authenticalable Address Amy is using the system
     And they have started the address journey
 
-  Scenario: Selecting an address
+  Scenario: Searching and successfully returning a postcode
     Given they searched for their postcode "T35T1N"
     Then they should see the results page
     And they have selected an address
+    Then they should be able to confirm the address
+
+  @run
+  Scenario: Searching and unsuccessfully finding an address
+    Given they searched for their postcode "XXX_XX"
+    Then they should see the address page
+    When they have added their details manually
     Then they should be able to confirm the address

--- a/test/application/pages/address.js
+++ b/test/application/pages/address.js
@@ -4,6 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
+    this.url = "http://localhost:5010/address";
   }
 
   async continue() {
@@ -11,10 +12,26 @@ module.exports = class PlaywrightDevPage {
   }
 
   async goto() {
-    await this.page.goto("http://localhost:5010/address");
+    await this.page.goto(this.url);
   }
 
   async getPageTitle() {
     return await this.page.textContent("#header");
+  }
+
+  isCurrentPage() {
+    return this.page.url() === this.url;
+  }
+
+  async addHouseNameOrNumber(value = "1A") {
+    await this.page.fill("#addressLine1", value);
+  }
+
+  async addStreet(value = "test") {
+    await this.page.fill("#addressLine2", value);
+  }
+
+  async addTownOrCity(value = "testTown") {
+    await this.page.fill("#addressTown", value);
   }
 };

--- a/test/application/step_definitions/address.js
+++ b/test/application/step_definitions/address.js
@@ -1,7 +1,15 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
-const { SearchPage, ResultsPage, ConfirmPage } = require("../pages");
+const {
+  SearchPage,
+  ResultsPage,
+  ConfirmPage,
+  AddressPage,
+} = require("../pages");
 const { expect } = require("chai");
 
+/**
+ * GIVEN
+ */
 Given(/^^([A-Za-z ])+ is using the system$/, async function (name) {
   this.user = this.allUsers[name];
 });
@@ -18,19 +26,38 @@ Given("they searched for their postcode {string}", async function (postcode) {
   await searchPage.searchPostcode(postcode);
 });
 
+/**
+ * THEN
+ */
 Then(/they should see the results page$/, async function () {
   const resultsPage = new ResultsPage(this.page);
   expect(resultsPage.isCurrentPage()).to.be.true;
-});
-
-When(/they (?:have )select(?:ed)? an address$/, async function () {
-  const resultPage = new ResultsPage(this.page);
-  await resultPage.selectAddress();
-  await resultPage.continue();
 });
 
 Then(/they should be able to confirm the address$/, async function () {
   const confirmPage = new ConfirmPage(this.page);
   expect(confirmPage.isCurrentPage()).to.be.true;
   await confirmPage.confirmDetails();
+});
+
+Then(/they should see the address page$/, async function () {
+  const addressPage = new AddressPage(this.page);
+  expect(addressPage.isCurrentPage()).to.be.true;
+});
+
+/**
+ * WHEN
+ */
+When(/they (?:have )select(?:ed)? an address$/, async function () {
+  const resultPage = new ResultsPage(this.page);
+  await resultPage.selectAddress();
+  await resultPage.continue();
+});
+
+When(/they (?:have )add(?:ed)? their details manually$/, async function () {
+  const addressPage = new AddressPage(this.page);
+  await addressPage.addHouseNameOrNumber();
+  await addressPage.addStreet();
+  await addressPage.addTownOrCity();
+  await addressPage.continue();
 });

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -49,6 +49,26 @@
           ]
         }
       }
+    },
+    {
+      "scenarioName": "Address",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "AddressResponses",
+      "request": {
+        "method": "GET",
+        "url": "/ordnance?&postcode=XXX_XX&key=secret",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-success"
+          }
+        }
+      },
+      "response": {
+        "status": 404,
+        "jsonBody": {
+          "results": []
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Address search should not throw an error when the Postcode API returns an error. Instead it should direct the user to the address confirmation page.

We allow the diverging paths by using the HMPO Form wizards conditional steps. By setting a variable called `isSuccessful` and setting that variable to false in an unsuccessful instance we can then direct the user journey to the address entry page rather than address results.

[HMPO-form-wizard docs for the step condition.](https://github.com/HMPO/hmpo-form-wizard#:~:text=%7B%20field%3A%20%27field1%27%2C%20op%3A%20(fieldValue%2C%20req%2C%20res%2C%20con)%20%3D%3E%20fieldValue%20%3D%3D%3D%20con.value%2C%20value%3A%20true%2C%20next%3A%20%27next%2Dstep%27%20%7D%2C)

Next iteration could be depending on the return code, do we pop up an error saying postcode not found.

NB: Is isSuccessful a good name? 

### Why did it change

This will keep the user inside a happy path journey by allowing them to manually enter their details if the postcode api returns an error.

### Issue tracking

- [KBV-201](https://govukverify.atlassian.net/browse/KBV-201)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed


--------

https://user-images.githubusercontent.com/8826525/155151960-97630d65-3571-4760-9c0e-4ad2eba928ca.mov




