### PR TITLE
Kbv 275 move postcode lookup to be

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ yarn install
 
 - `BASE_URL`: Externally accessible base url of the webserver. Used to generate the callback url as part of credential issuer oauth flows
 - `PORT` - Default port to run webserver on. (Default to `5010`)
-- `ORDNANCE_SURVEY_SECRET`- The api key for the ordnance postcode look up api.
 
 # Testing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The frontend can be configure to use this server through changing two environmen
 
 - `NODE_ENV = development` - this enables a midldeware that passes the `x-scenario-id` header from web requests through to the API.
 - `API_BASE_URL = http://localhost:8090` - this points the frontend to the wiremock instance.
-- `ORDNANCE_API_URL = http://localhost:8090` - this points to an external API for address lookup. <!-- TODO: Move Ordnance to BE -->
 
 A browser extension that can modify headers can be used to set the value of the header in a web browser. Example - [Mod Header](https://modheader.com)
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/app.js",
-    "start:ci": "ORDNANCE_SURVEY_SECRET=secret NODE_ENV=development API_BASE_URL=http://localhost:8090/ ORDNANCE_SURVEY_URL=http://localhost:8090/ordnance? yarn dev",
+    "start:ci": "NODE_ENV=development API_BASE_URL=http://localhost:8090/ yarn dev",
     "dev": "nodemon src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",

--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -20,16 +20,16 @@ class AddressController extends BaseController {
 
   async saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
-      const addressLine1 = req.body["addressLine1"];
-      const addressLine2 = req.body["addressLine2"];
-      const addressTown = req.body["addressTown"];
-      const addressPostcode = req.sessionModel.get("addressPostcode");
+      const buildingNumber = req.body["addressLine1"];
+      const thoroughfareName = req.body["addressLine2"];
+      const postTown = req.body["addressTown"];
+      const postcode = req.sessionModel.get("addressPostcode");
       const address = {
-        addressLine1,
-        addressLine2,
-        addressTown,
-        addressPostcode
-      }
+        buildingNumber,
+        thoroughfareName,
+        postTown,
+        postcode,
+      };
       const sessionsAddresses = req.sessionModel.get("addresses");
 
       const addresses = Array.isArray(sessionsAddresses)

--- a/src/app/address/controllers/address.test.js
+++ b/src/app/address/controllers/address.test.js
@@ -36,8 +36,8 @@ describe("address controller", () => {
 
     const savedAddress = req.session.test.addresses[0];
     expect(next).to.have.been.calledOnce;
-    expect(savedAddress.addressLine1).to.equal(addressToSave.addressLine1);
-    expect(savedAddress.addressLine2).to.equal(addressToSave.addressLine2);
-    expect(savedAddress.addressTown).to.equal(addressToSave.addressTown);
+    expect(savedAddress.buildingNumber).to.equal(addressToSave.addressLine1);
+    expect(savedAddress.thoroughfareName).to.equal(addressToSave.addressLine2);
+    expect(savedAddress.postTown).to.equal(addressToSave.addressTown);
   });
 });

--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -33,7 +33,7 @@ class AddressConfirmController extends BaseController {
   }
 
   formatAddress(address) {
-    return `${address.addressLine1}<br>${address.addressLine2},<br>${address.addressTown},<br>${address.addressPostcode}<br>`;
+    return `${address.buildingNumber}<br>${address.thoroughfareName},<br>${address.postTown},<br>${address.postcode}<br>`;
   }
 }
 

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -36,7 +36,7 @@ describe("Address confirmation controller", () => {
     req.sessionModel.set("addresses", addresses);
 
     const formattedAddresses = addresses.map((address) => {
-      return `${address.addressLine1}<br>${address.addressLine2},<br>${address.addressTown},<br>${address.addressPostcode}<br>`;
+      return `${address.buildingNumber}<br>${address.thoroughfareName},<br>${address.postTown},<br>${address.postcode}<br>`;
     });
 
     const currentAddress = formattedAddresses.shift();

--- a/src/app/address/controllers/addressResults.js
+++ b/src/app/address/controllers/addressResults.js
@@ -15,15 +15,11 @@ class AddressResultsController extends BaseController {
         const allAddresses = req.sessionModel.get("searchResults");
 
         const choosenAddress = allAddresses.find(
-          (address) => address.label === selectedAddress
+          (address) => address.text === selectedAddress
         );
 
-        const address = {
-          addressLine1: choosenAddress.buildingNumber,
-          addressLine2: choosenAddress.streetName,
-          addressTown: choosenAddress.town,
-          addressPostcode: choosenAddress.postcode,
-        };
+        delete choosenAddress.value;
+        delete choosenAddress.text;
 
         const sessionAddresses = req.sessionModel.get("addresses");
 
@@ -31,7 +27,7 @@ class AddressResultsController extends BaseController {
           ? sessionAddresses
           : [];
 
-        addresses.push(address);
+        addresses.push(choosenAddress);
 
         req.sessionModel.set("addresses", addresses);
         callback();

--- a/src/app/address/controllers/addressResults.test.js
+++ b/src/app/address/controllers/addressResults.test.js
@@ -34,24 +34,24 @@ describe("Address result controller", () => {
   it("Should set the chosen address in the session", async () => {
     const expectedResponse = testData.formattedAddressed[1];
 
-    req.body["address-selection"] = expectedResponse.label;
+    req.body["address-selection"] = expectedResponse.value;
 
     req.sessionModel.set("searchResults", testData.formattedAddressed);
 
     await addressResult.saveValues(req, res, next);
 
     expect(next).to.have.been.calledOnce;
-    expect(req.session.test.addresses[0].addressLine1).to.equal(
+    expect(req.session.test.addresses[0].buildingNumber).to.equal(
       expectedResponse.buildingNumber
     );
-    expect(req.session.test.addresses[0].addressLine2).to.equal(
-      expectedResponse.streetName
+    expect(req.session.test.addresses[0].thoroughfareName).to.equal(
+      expectedResponse.thoroughfareName
     );
-    expect(req.session.test.addresses[0].addressPostcode).to.equal(
+    expect(req.session.test.addresses[0].postcode).to.equal(
       expectedResponse.postcode
     );
-    expect(req.session.test.addresses[0].addressTown).to.equal(
-      expectedResponse.town
+    expect(req.session.test.addresses[0].postTown).to.equal(
+      expectedResponse.postTown
     );
   });
 });

--- a/src/app/address/controllers/addressSearch.test.js
+++ b/src/app/address/controllers/addressSearch.test.js
@@ -1,15 +1,19 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const AddressSearchController = require("./addressSearch");
 
-const {
-  ORDNANCE: { ORDNANCE_SURVEY_SECRET },
-} = require("../../../lib/config");
 const testData = require("../../../../test/data/testData");
+
+const {
+  API: {
+    PATHS: { POSTCODE_LOOKUP },
+  },
+} = require("../../../lib/config");
 
 let req;
 let res;
 let next;
 let sandbox;
+const sessionId = "session-id-123";
 
 beforeEach(() => {
   sandbox = sinon.createSandbox();
@@ -17,6 +21,7 @@ beforeEach(() => {
   req = setup.req;
   res = setup.res;
   next = setup.next;
+  req.session.tokenId = sessionId;
 });
 
 afterEach(() => {
@@ -36,22 +41,26 @@ describe("Address Search controller", () => {
 
   it("Should call api with a postcode and save results to session", async () => {
     const testPostcode = "myPostcode";
-    req.ordnanceAxios.get = sinon.fake.returns(testData.apiResponse);
+    req.axios.get = sinon.fake.returns(testData.apiResponse);
     req.body["address-search"] = testPostcode;
 
     await addressSearch.saveValues(req, res, next);
 
     expect(next).to.have.been.calledOnce;
-    expect(req.ordnanceAxios.get).to.have.been.calledWith(null, {
-      params: {
-        postcode: testPostcode,
-        key: ORDNANCE_SURVEY_SECRET,
-      },
-    });
+    expect(req.axios.get).to.have.been.calledWith(
+      `${POSTCODE_LOOKUP}/${testPostcode}`,
+      {
+        headers: {
+          session_id: sessionId,
+        },
+      }
+    );
     expect(req.session.test.addressPostcode).to.equal(testPostcode);
     expect(req.session.test.searchResults[0].buildingNumber).to.equal("1");
-    expect(req.session.test.searchResults[0].streetName).to.equal("SOME ROAD");
-    expect(req.session.test.searchResults[0].town).to.equal("SOMEWHERE");
+    expect(req.session.test.searchResults[0].thoroughfareName).to.equal(
+      "SOME ROAD"
+    );
+    expect(req.session.test.searchResults[0].postTown).to.equal("SOMEWHERE");
     expect(req.session.test.searchResults[0].postcode).to.equal("SOMEPOST");
     expect(req.session.test.searchResults[1].buildingNumber).to.equal(
       "NAMED BUILDING"
@@ -61,18 +70,20 @@ describe("Address Search controller", () => {
 
   it("Should not throw an error when api throws error", async () => {
     const testPostcode = "myPostcode";
-    req.ordnanceAxios.get = sinon.fake.rejects();
+    req.axios.get = sinon.fake.rejects();
     req.body["address-search"] = testPostcode;
 
     await addressSearch.saveValues(req, res, next);
 
     expect(next).to.have.been.calledOnce;
-    expect(req.ordnanceAxios.get).to.have.been.calledWith(null, {
-      params: {
-        postcode: testPostcode,
-        key: ORDNANCE_SURVEY_SECRET,
-      },
-    });
+    expect(req.axios.get).to.have.been.calledWith(
+      `${POSTCODE_LOOKUP}/${testPostcode}`,
+      {
+        headers: {
+          session_id: sessionId,
+        },
+      }
+    );
     expect(req.session.test.addressPostcode).to.equal(testPostcode);
     expect(req.session.test.requestIsSuccessful).to.equal(false);
   });

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -42,8 +42,7 @@ module.exports = {
             headers: headers,
           }
         );
-
-        req.session.tokenId = apiResponse?.data["session-id"];
+        req.session.tokenId = apiResponse?.data["session_id"];
       }
     } catch (error) {
       next(error);

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -1,7 +1,6 @@
 const axios = require("axios");
 const {
   API: { BASE_URL },
-  ORDNANCE: { ORDNANCE_API_URL },
 } = require("./config");
 
 module.exports = function (req, res, next) {
@@ -11,16 +10,6 @@ module.exports = function (req, res, next) {
 
   if (req.scenarioIDHeader) {
     req.axios.defaults.headers.common["x-scenario-id"] = req.scenarioIDHeader;
-  }
-
-  // todo remove once ordnance has migrated to BE
-  req.ordnanceAxios = axios.create({
-    baseURL: ORDNANCE_API_URL,
-  });
-
-  if (req.scenarioIDHeader) {
-    req.ordnanceAxios.defaults.headers.common["x-scenario-id"] =
-      req.scenarioIDHeader;
   }
 
   next();

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -2,10 +2,11 @@ require("dotenv").config();
 
 module.exports = {
   API: {
-    BASE_URL: process.env.API_BASE_URL || "http://localhost:5007",
+    BASE_URL: process.env.API_BASE_URL || "http://localhost:5007/",
     PATHS: {
       AUTHORIZE: "session",
       AUTHORIZATION_CODE: "authorization-code",
+      POSTCODE_LOOKUP: "postcode-lookup",
     },
   },
   APP: {
@@ -19,11 +20,5 @@ module.exports = {
   REDIS: {
     SESSION_URL: process.env.REDIS_SESSION_URL,
     PORT: process.env.REDIS_PORT || 6379,
-  },
-  ORDNANCE: {
-    ORDNANCE_SURVEY_SECRET: process.env.ORDNANCE_SURVEY_SECRET,
-    ORDNANCE_API_URL:
-      process.env.ORDNANCE_SURVEY_URL ||
-      "https://api.os.uk/search/places/v1/postcode?",
   },
 };

--- a/test/browser/pages/result.js
+++ b/test/browser/pages/result.js
@@ -11,7 +11,7 @@ module.exports = class PlaywrightDevPage {
     return this.page.url() === this.url;
   }
 
-  async selectAddress(value = "TEST ADDRESS 2") {
+  async selectAddress(value = "2A TEST STREET, TESTTOWN, TE5T1NG") {
     await this.page.click(".govuk-select");
     await this.page.selectOption(".govuk-select", {
       value,

--- a/test/browser/step_definitions/address.js
+++ b/test/browser/step_definitions/address.js
@@ -102,6 +102,6 @@ When(/they (?:have )add(?:ed)? their details manually$/, async function () {
 
 When(/they have selected their previous address$/, async function () {
   const resultsPage = new ResultsPage(this.page);
-  await resultsPage.selectAddress("PREVIOUS ADDRESS 3");
+  await resultsPage.selectAddress("3A TEST STREET, TESTTOWN, PR3VC0DE");
   await resultsPage.continue();
 });

--- a/test/data/testData.js
+++ b/test/data/testData.js
@@ -1,42 +1,36 @@
 module.exports = {
   apiResponse: {
-    data: {
-      results: [
-        {
-          DPA: {
-            ADDRESS: "1, SOME ROAD, SOMEWHERE, SOMEPOST",
-            BUILDING_NUMBER: "1",
-            THOROUGHFARE_NAME: "SOME ROAD",
-            POST_TOWN: "SOMEWHERE",
-            POSTCODE: "SOMEPOST",
-          },
-        },
-        {
-          DPA: {
-            ADDRESS: "2, SOME ROAD, SOMEWHERE, SOMEPOST",
-            BUILDING_NAME: "NAMED BUILDING",
-            THOROUGHFARE_NAME: "SOME ROAD",
-            POST_TOWN: "SOMEWHERE",
-            POSTCODE: "SOMEPOST",
-          },
-        },
-      ],
-    },
+    data: [
+      {
+        buildingNumber: "1",
+        thoroughfareName: "SOME ROAD",
+        postTown: "SOMEWHERE",
+        postcode: "SOMEPOST",
+      },
+      {
+        buildingNumber: "NAMED BUILDING",
+        thoroughfareName: "SOME ROAD",
+        postTown: "SOMEWHERE",
+        postcode: "SOMEPOST",
+      },
+    ],
   },
   formattedAddressed: [
     {
       buildingNumber: "1",
-      streetName: "SOME ROAD",
-      town: "SOMEWHERE",
+      thoroughfareName: "SOME ROAD",
+      postTown: "SOMEWHERE",
       postcode: "SOMEPOST",
-      label: "1, SOMEROAD, SOMEWHERE, SOMEPOST",
+      text: "1, SOMEROAD, SOMEWHERE, SOMEPOST",
+      value: "1, SOMEROAD, SOMEWHERE, SOMEPOST",
     },
     {
       buildingNumber: "NAMED BUILDING",
-      streetName: "SOME ROAD",
-      town: "SOMEWHERE",
+      thoroughfareName: "SOME ROAD",
+      postTown: "SOMEWHERE",
       postcode: "SOMEPOST",
-      label: "NAMED BUILDING, SOMEROAD, SOMEWHERE, SOMEPOST",
+      text: "NAMED BUILDING, SOMEROAD, SOMEWHERE, SOMEPOST",
+      value: "NAMED BUILDING, SOMEROAD, SOMEWHERE, SOMEPOST",
     },
   ],
 };

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -17,7 +17,7 @@
       "newScenarioState": "AddressResponses",
       "request": {
         "method": "GET",
-        "url": "/ordnance?&postcode=T35T1N&key=secret",
+        "url": "/postcode-lookup/T35T1N",
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
@@ -26,28 +26,20 @@
       },
       "response": {
         "status": 200,
-        "jsonBody": {
-          "results": [
-            {
-              "DPA": {
-                "ADDRESS": "TEST ADDRESS 1",
-                "BUILDING_NUMBER": "1",
-                "POST_TOWN": "TESTTOWN",
-                "POSTCODE": "TE5T1NG",
-                "THOROUGHFARE_NAME": "TEST STREET"
-              }
-            },
-            {
-              "DPA": {
-                "ADDRESS": "TEST ADDRESS 2",
-                "BUILDING_NAME": "2A",
-                "POST_TOWN": "TESTTOWN",
-                "POSTCODE": "TE5T1NG",
-                "THOROUGHFARE_NAME": "TEST STREET"
-              }
-            }
-          ]
-        }
+        "jsonBody": [
+          {
+            "buildingNumber": "1",
+            "postTown": "TESTTOWN",
+            "postcode": "TE5T1NG",
+            "thoroughfareName": "TEST STREET"
+          },
+          {
+            "buildingNumber": "2A",
+            "postTown": "TESTTOWN",
+            "postcode": "TE5T1NG",
+            "thoroughfareName": "TEST STREET"
+          }
+        ]
       }
     },
     {
@@ -56,7 +48,7 @@
       "newScenarioState": "AddressResponses",
       "request": {
         "method": "GET",
-        "url": "/ordnance?&postcode=XXX_XX&key=secret",
+        "url": "/postcode-lookup/XXX_XX",
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
@@ -65,9 +57,7 @@
       },
       "response": {
         "status": 404,
-        "jsonBody": {
-          "results": []
-        }
+        "jsonBody": []
       }
     },
     {
@@ -76,7 +66,7 @@
       "newScenarioState": "AddressResponses",
       "request": {
         "method": "GET",
-        "url": "/ordnance?&postcode=PR3VC0DE&key=secret",
+        "url": "/postcode-lookup/PR3VC0DE",
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
@@ -85,37 +75,26 @@
       },
       "response": {
         "status": 200,
-        "jsonBody": {
-          "results": [
-            {
-              "DPA": {
-                "ADDRESS": "PREVIOUS ADDRESS 1",
-                "BUILDING_NUMBER": "1",
-                "POST_TOWN": "TESTTOWN",
-                "POSTCODE": "PR3VC0DE",
-                "THOROUGHFARE_NAME": "TEST STREET"
-              }
-            },
-            {
-              "DPA": {
-                "ADDRESS": "PREVIOUS ADDRESS 2",
-                "BUILDING_NAME": "2A",
-                "POST_TOWN": "TESTTOWN",
-                "POSTCODE": "PR3VC0DE",
-                "THOROUGHFARE_NAME": "TEST STREET"
-              }
-            },
-            {
-              "DPA": {
-                "ADDRESS": "PREVIOUS ADDRESS 3",
-                "BUILDING_NAME": "3A",
-                "POST_TOWN": "TESTTOWN",
-                "POSTCODE": "PR3VC0DE",
-                "THOROUGHFARE_NAME": "TEST STREET"
-              }
-            }
-          ]
-        }
+        "jsonBody": [
+          {
+            "buildingNumber": "1",
+            "postTown": "TESTTOWN",
+            "postcode": "PR3VC0DE",
+            "thoroughfareName": "TEST STREET"
+          },
+          {
+            "buildingNumber": "2A",
+            "postTown": "TESTTOWN",
+            "postcode": "PR3VC0DE",
+            "thoroughfareName": "TEST STREET"
+          },
+          {
+            "buildingNumber": "3A",
+            "postTown": "TESTTOWN",
+            "postcode": "PR3VC0DE",
+            "thoroughfareName": "TEST STREET"
+          }
+        ]
       }
     }
   ]

--- a/test/utils/addressFactory.js
+++ b/test/utils/addressFactory.js
@@ -2,10 +2,10 @@ function addressFactory(quantity) {
   const addresses = [];
   for (let i = 0; i < quantity; i++) {
     addresses.push({
-      addressLine1: `${i} house`,
-      addressLine2: `${i} street`,
-      addressTown: `${i} town`,
-      addressPostcode: `${i} code`,
+      buildingNumber: `${i} house`,
+      thoroughfareName: `${i} street`,
+      postTown: `${i} town`,
+      postcode: `${i} code`,
     });
   }
   return addresses;

--- a/test/utils/mocha-helpers.js
+++ b/test/utils/mocha-helpers.js
@@ -21,9 +21,6 @@ global.setupDefaultMocks = () => {
       get: sinon.fake(),
       post: sinon.fake(),
     },
-    ordnanceAxios: {
-      get: sinon.fake(),
-    },
   });
 
   req.journeyModel = new JourneyModel(null, {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- call postcode api with session header and the postcode rather than the ordnance survey directly.
- session header correction.
- Browser tests and unit test refactor.
- refactor the Axios instance creation.
- Update readme

### Why did it change

Now we've move the postcode lookup to the backend we should use it.
This provides an additional layer of security in managing the postcode api secrets.
With this change we need to update the browser tests, the unit tests, the readme and the created axios instances.

### Issue tracking

- [KBV-275](https://govukverify.atlassian.net/browse/KBV-275)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks
