### PR TITLE
KBV 285 call address api from frontend

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -1,10 +1,15 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 
+const {
+  API: {
+    PATHS: { SAVE_ADDRESS },
+  },
+} = require("../../../lib/config");
+
 class AddressConfirmController extends BaseController {
   locals(req, res, callback) {
     super.locals(req, res, (err, locals) => {
       const sessionAddresses = req.sessionModel.get("addresses");
-
 
       const addresses = sessionAddresses.map((address) => {
         return this.formatAddress(address);
@@ -14,7 +19,6 @@ class AddressConfirmController extends BaseController {
 
       locals.formattedAddress = currentAddress;
 
-      // format previous addresses
       if (addresses.length) {
         locals.previousAddresses = addresses;
       }
@@ -24,11 +28,20 @@ class AddressConfirmController extends BaseController {
   }
 
   saveValues(req, res, callback) {
-    super.saveValues(req, res, () => {
-      // temporary until add previous addresses has been confirmed.
-      const addPreviousAddresses = req.body.addPreviousAddresses !== null;
-      req.sessionModel.set("addPreviousAddresses", addPreviousAddresses);
-      callback();
+    super.saveValues(req, res, async () => {
+      try {
+        const addresses = req.sessionModel.get("addresses");
+
+        const data = await this.saveAddressess(
+          req.axios,
+          addresses,
+          req.session.tokenId
+        );
+
+        res.json({ response: data }); // todo handle redirect
+      } catch (err) {
+        callback(err);
+      }
     });
   }
 
@@ -41,6 +54,16 @@ class AddressConfirmController extends BaseController {
     }
 
     return `${buildingNameNumber}<br>${address.thoroughfareName},<br>${address.postTown},<br>${address.postcode}<br>`;
+  }
+
+  async saveAddressess(axios, addresses, sessionId) {
+    // set the headers to undefined will a fail a production level request but pass the browser tests for now.
+    const headers = sessionId ? { session_id: sessionId } : undefined;
+    const resp = await axios.put(`${SAVE_ADDRESS}`, addresses, {
+      headers,
+    });
+
+    return resp.data;
   }
 }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -7,6 +7,7 @@ module.exports = {
       AUTHORIZE: "session",
       AUTHORIZATION_CODE: "authorization-code",
       POSTCODE_LOOKUP: "postcode-lookup",
+      SAVE_ADDRESS: "address",
     },
   },
   APP: {

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -5,8 +5,9 @@
 {% extends "form-template.njk" %}
 {% set hmpoPageKey = "address-confirm" %}
 
-{% block innerContent %}
-  {{ super() }}
+{% block mainContent %}
+
+  <h1 id="header">{{translate("pages.address-confirm.title")}}</h1>
 
   {{ govukWarningText({
     text: translate("pages.address-confirm.warning"),
@@ -34,10 +35,16 @@
 
   {% endif %}
 
-  {{hmpoSubmit(ctx, {
-    id: "addPreviousAddresses",
-    key: "Add another address path"
-  })}}
+  {% call hmpoForm(ctx) %}
+    {{ hmpoSubmit(ctx, {
+        text: translate("buttons.next"),
+        attributes: {
+        "data-id": "next"
+      }
+    }) }}
+  {% endcall %}
+
+
 
   <br>
 {% endblock %}

--- a/test/browser/features/address-previous.feature
+++ b/test/browser/features/address-previous.feature
@@ -1,14 +1,15 @@
-@mock-api:address-success @success
-Feature: Searching and successfull adding multiple addresses
-  Adding multiple addresses journey
+#  these will be reaadded when the previous address feature workflow is confirmed.
+# @mock-api:address-success @success
+# Feature: Searching and successfull adding multiple addresses
+#   Adding multiple addresses journey
 
-  Background:
-    Given Authenticalable Address Amy is using the system
-    And they have added their current postcode "T35T1N"
-    And they have entered the previous address journey
+#   Background:
+#     Given Authenticalable Address Amy is using the system
+#     And they have added their current postcode "T35T1N"
+#     And they have entered the previous address journey
 
-  Scenario: Searching and successfull adding their previous postcode
-    Given they have searched for their previous postcode "PR3VC0DE"
-    Then they should see the previous results page
-    When they have selected their previous address
-    Then they should be able confirm both their addresses
+#   Scenario: Searching and successfull adding their previous postcode
+#     Given they have searched for their previous postcode "PR3VC0DE"
+#     Then they should see the previous results page
+#     When they have selected their previous address
+#     Then they should be able confirm both their addresses

--- a/test/browser/pages/confirm.js
+++ b/test/browser/pages/confirm.js
@@ -11,9 +11,8 @@ module.exports = class PlaywrightDevPage {
     await this.page.click("#change-address");
   }
 
-  // TODO change selector to data-id
   async confirmDetails() {
-    await this.page.locator(":nth-match(.govuk-button, 2)");
+    await this.page.click('[data-id="next"]');
   }
 
   async previousAddressButton() {

--- a/test/data/testData.js
+++ b/test/data/testData.js
@@ -33,4 +33,11 @@ module.exports = {
       value: "NAMED BUILDING, SOMEROAD, SOMEWHERE, SOMEPOST",
     },
   ],
+  addressApiResponse: {
+    data: {
+      code: "mySuperSecretCode",
+      state: "myAwesomeState",
+      redirect_uri: "http://localhost:8085/callback",
+    },
+  },
 };

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -96,6 +96,30 @@
           }
         ]
       }
+    },
+    {
+      "scenarioName": "Address",
+      "requiredScenarioState": "AddressResponses",
+      "newScenarioState": "AddressResponses",
+      "request": {
+        "method": "PUT",
+        "url": "/address",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-success"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "jsonBody": {
+          "data": {
+            "code": "mySuperSecretCode",
+            "state": "myAwesomeState",
+            "redirect_uri": "http://localhost:8085/callback"
+          }
+        }
+      }
     }
   ]
 }

--- a/test/utils/mocha-helpers.js
+++ b/test/utils/mocha-helpers.js
@@ -20,6 +20,7 @@ global.setupDefaultMocks = () => {
     axios: {
       get: sinon.fake(),
       post: sinon.fake(),
+      put: sinon.fake(),
     },
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Now we have a backend to send addresses too, we can now point the Frontend to the backend. This makes the relevant changes.
Temporarily I've paused the addition of adding previous addresses as the work to finalise the designs and content is still underway. 

For the time being I'm just rendering the JSON block onto the screen. A separate PR will be created to complete the redirect to the stub. This is to keep the PR's small enough to review quicker.

### Why did it change

This is part of the work for the address CRI happy path.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-285](https://govukverify.atlassian.net/browse/KBV-285)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed