### PR TITLE
KBV-294-redirect-to-callback-url

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -38,7 +38,17 @@ class AddressConfirmController extends BaseController {
           req.session.tokenId
         );
 
-        this.redirectToCallback(res, data.redirect_uri, data.state, data.code);
+        if (!data.code) {
+          const error = {
+            code: "server_error",
+            error_description: "Failed to retrieve authorization code",
+          };
+          req.sessionModel.set("error", error);
+          callback();
+        } else {
+          req.sessionModel.set("authorization_code", data.code);
+          callback();
+        }
       } catch (err) {
         callback(err);
       }
@@ -66,14 +76,6 @@ class AddressConfirmController extends BaseController {
     return resp.data;
   }
 
-  redirectToCallback(res, uri, state, code) {
-    const url = new URL(uri);
-    url.searchParams.append("code", code);
-    url.searchParams.append("state", state);
-    url.searchParams.append("id", "address");
-
-    res.redirect(url.toString());
-  }
 }
 
 module.exports = AddressConfirmController;

--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -38,7 +38,7 @@ class AddressConfirmController extends BaseController {
           req.session.tokenId
         );
 
-        res.json({ response: data }); // todo handle redirect
+        this.redirectToCallback(res, data.redirect_uri, data.state, data.code);
       } catch (err) {
         callback(err);
       }
@@ -64,6 +64,15 @@ class AddressConfirmController extends BaseController {
     });
 
     return resp.data;
+  }
+
+  redirectToCallback(res, uri, state, code) {
+    const url = new URL(uri);
+    url.searchParams.append("code", code);
+    url.searchParams.append("state", state);
+    url.searchParams.append("id", "address");
+
+    res.redirect(url.toString());
   }
 }
 

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -47,7 +47,7 @@ module.exports = {
         value: true,
         next: "previous",
       },
-      "done",
+      "/oauth2/callback",
     ],
   },
   "/previous": {

--- a/src/app/oauth2/index.js
+++ b/src/app/oauth2/index.js
@@ -5,7 +5,6 @@ const router = express.Router();
 const {
   addAuthParamsToSession,
   redirectToCallback,
-  retrieveAuthorizationCode,
   initSessionWithJWT,
   redirectToAddress,
   addJWTToRequest,
@@ -18,6 +17,6 @@ router.get(
   initSessionWithJWT,
   redirectToAddress
 );
-router.post("/authorize", retrieveAuthorizationCode, redirectToCallback);
+router.get("/callback", redirectToCallback);
 
 module.exports = router;

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,6 +6,7 @@ module.exports = {
     PATHS: {
       AUTHORIZE: "session",
       AUTHORIZATION_CODE: "authorization-code",
+      AUTHORIZATION_TOKEN: "token",
       POSTCODE_LOOKUP: "postcode-lookup",
       SAVE_ADDRESS: "address",
     },


### PR DESCRIPTION
## Proposed changes

### What changed
Added a redirection after the addresses have been saved.
### Why did it change

We should redirect back to callback URL with the auth code and state.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-294](https://govukverify.atlassian.net/browse/KBV-294)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
