### PR TITLE
BAU-test fix for confirmAddress-saveValues signature is incorrect

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -27,32 +27,30 @@ class AddressConfirmController extends BaseController {
     });
   }
 
-  saveValues(req, res, callback) {
-    super.saveValues(req, res, async () => {
-      try {
-        const addresses = req.sessionModel.get("addresses");
-
-        const data = await this.saveAddressess(
-          req.axios,
-          addresses,
-          req.session.tokenId
-        );
-
+  async saveValues(req, res, callback) {
+    try {
+      const addresses = req.sessionModel.get("addresses");
+      const data = await this.saveAddressess(
+        req.axios,
+        addresses,
+        req.session.tokenId
+      );
+      super.saveValues(req, res, () => {
         if (!data.code) {
           const error = {
             code: "server_error",
             error_description: "Failed to retrieve authorization code",
           };
+
           req.sessionModel.set("error", error);
-          callback();
         } else {
           req.sessionModel.set("authorization_code", data.code);
-          callback();
         }
-      } catch (err) {
-        callback(err);
-      }
-    });
+        callback();
+      });
+    } catch (err) {
+      callback(err);
+    }
   }
 
   formatAddress(address) {
@@ -75,7 +73,6 @@ class AddressConfirmController extends BaseController {
 
     return resp.data;
   }
-
 }
 
 module.exports = AddressConfirmController;

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -70,16 +70,15 @@ describe("Address confirmation controller", () => {
   it("Should put address to address api and redirect back to callback", async () => {
     req.axios.put = sinon.fake.resolves(testData.addressApiResponse);
 
-    await addressConfirm.saveValues(req, res, () => {
-      expect(req.axios.put).to.have.been.calledWith(SAVE_ADDRESS, addresses, {
-        headers: {
-          session_id: sessionId,
-        },
-      });
-      expect(req.session.test.authorization_code).to.be.equal(
-        testData.addressApiResponse.data.code
-      );
+    await addressConfirm.saveValues(req, res, next);
+    expect(req.axios.put).to.have.been.calledWith(SAVE_ADDRESS, addresses, {
+      headers: {
+        session_id: sessionId,
+      },
     });
+    expect(req.session.test.authorization_code).to.be.equal(
+      testData.addressApiResponse.data.code
+    );
   });
 
   it("Should set error state if no code is returned", async () => {
@@ -87,13 +86,10 @@ describe("Address confirmation controller", () => {
     delete response.data.code;
     req.axios.put = sinon.fake.resolves(response);
 
-    await addressConfirm.saveValues(req, res, () => {
-      expect(req.session.test.error.code).to.be.equal("server_error");
-      expect(req.session.test.error_description).to.be.equal(
-        "Failed to retrieve authorization code"
-      );
-    });
-
-    // expect(req.session.test.error).to.be.equal("server_error");
+    await addressConfirm.saveValues(req, res, next);
+    expect(req.session.test.error.code).to.be.equal("server_error");
+    expect(req.session.test.error.error_description).to.be.equal(
+      "Failed to retrieve authorization code"
+    );
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Test fix for the saveValues. 
SaveValues function signature is incorrect. As a result of async hell, test would "pass" but they're not actually testing anything.

### Why did it change

Fixing false positive tests.
