### PR TITLE
[KBV-336] Restore mocked browser tests

### DIFF
--- a/test/browser/.env.sample
+++ b/test/browser/.env.sample
@@ -1,0 +1,5 @@
+CORE_STUB_CONFIG_DIRECTORY=/path/to/config/dir/containing/keystore/and/user/data/file
+CREDENTIAL_ISSUER_LABEL="Label of button as configured in di-ipv-config file"
+CORE_STUB_URL=http://core-stub-instance:8085/
+MOCK_API_URL=http://wiremock-instance:port
+MOCK_API=false

--- a/test/browser/README.md
+++ b/test/browser/README.md
@@ -1,0 +1,41 @@
+# Running the browser tests
+
+A number of environment variables are needed by the browser tests, as they affect how Playwright is setup, and affect some of the Before/After hooks in cucumberjs.
+
+## Environment variables
+
+| env var                    | example                        | description                                                       |
+|----------------------------|--------------------------------|-------------------------------------------------------------------|
+| CORE_STUB_CONFIG_DIRECTORY | config/stubs/di-ipv-core-stub/ | Location of the config directory including the Keystore           |
+| CREDENTIAL_ISSUER_LABEL    | Address Development            | Label to click on inside the Core stub instance                   |
+| CORE_STUB_URL              | http://localhost:8085          | URL of the core stub, where the tests start                       |
+| MOCK_API_URL               | http://localhost:8090          | URL of the mock API, used to reset scenarios as required          |
+| MOCK_API                   | true                           | Use the mock API                                                  |
+
+
+## Running against mocks
+
+Required environment variables:
+
+- `CORE_STUB_CONFIG_DIRECTORY` - config/stubs/di-ipv-core-stub/
+- `CREDENTIAL_ISSUER_LABEL`- Address Local
+- `CORE_STUB_URL` - http://localhost:8085
+- `MOCK_API_URL` - http://localhost:8090
+- `MOCK_API` - true
+
+1. `docker-compose up`
+2. `yarn run cucumber-js --config test/browser/cucumber.js`
+   - `yarn run` runs from the root directory, so the full path to the config file needs to be specified
+
+## Running against environment
+
+Required environment variables:
+
+- `CREDENTIAL_ISSUER_LABEL` - Address CRI Dev
+- `CORE_STUB_URL` - https://di-ipv-core-stub.example.org
+- `MOCK_API` - false
+
+1. `yarn run cucumber-js --config test/browser/cucumber.js`
+   - `yarn run` runs from the root directory, so the full path to the config file needs to be specified
+
+

--- a/test/browser/compose.yml
+++ b/test/browser/compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+services:
+  db:
+    image: redis
+  mocks:
+    image: wiremock/wiremock
+    volumes:
+      - "../mocks:/home/wiremock"
+    ports:
+      - "8090:8080"
+  core-stub:
+    image: ghcr.io/alphagov/di/di-ipv-core-stub:latest
+    environment:
+      CORE_STUB_CONFIG_FILE: "/app/di-ipv-config.yaml"
+      CORE_STUB_KEYSTORE_ALIAS: ipv-core-stub
+      CORE_STUB_KEYSTORE_PASSWORD: "puppet"
+      CORE_STUB_KEYSTORE_FILE: "/app/keystore.jks"
+      CORE_STUB_USER_DATA_PATH: "/app/experian-uat-users-large.zip"
+
+    volumes:
+      - "./di-ipv-config.yaml:/app/di-ipv-config.yaml"
+      - "${CORE_STUB_CONFIG_DIRECTORY}/keystore.jks:/app/keystore.jks"
+      - "${CORE_STUB_CONFIG_DIRECTORY}/experian-uat-users-large.zip:/app/experian-uat-users-large.zip"
+    ports:
+      - "8085:8085"
+  web-address:
+    build:
+      context: ../..
+      dockerfile: local.Dockerfile
+    environment:
+      REDIS_SESSION_URL: db
+      API_BASE_URL: http://172.17.0.1:8090
+#      API_BASE_URL: http://mocks:8090
+      PORT: 5010
+      NODE_ENV: development
+    ports:
+      - "5010:5010"
+    depends_on:
+      - db
+      - mocks
+      - core-stub
+    links:
+      - mocks

--- a/test/browser/cucumber.js
+++ b/test/browser/cucumber.js
@@ -1,7 +1,7 @@
 module.exports = {
   default: {
     publishQuiet: true,
-    paths: ["./features/**/**.feature"],
-    require: ["./support/**/*.js", "./step_definitions/**/*.js"],
+    paths: ["./test/browser/features/**/**.feature"],
+    require: ["./test/browser/support/**/*.js", "./test/browser/step_definitions/**/*.js"],
   },
 };

--- a/test/browser/di-ipv-config.yaml
+++ b/test/browser/di-ipv-config.yaml
@@ -1,0 +1,7 @@
+credentialIssuerConfigs:
+  - id: kbv
+    name: Address Local
+    authorizeUrl: http://localhost:5010/oauth2/authorize
+    tokenUrl: http://172.17.0.1:8090/oauth2/token
+    credentialUrl: http://172.17.0.1:8090/oauth2/credential
+    sendIdentityClaims: false

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -44,7 +44,7 @@ Before(async function ({ pickle } = {}) {
 
   this.SCENARIO_ID_HEADER = header;
 
-  await axios.get(`http://localhost:8090/__reset/${header}`);
+  await axios.get(`${process.env.MOCK_API_URL}/__reset/${header}`);
 });
 
 // Create a new test context and page per scenario

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -14,6 +14,26 @@
     {
       "scenarioName": "Address",
       "requiredScenarioState": "Started",
+      "newScenarioState": "PostcodeLookup",
+      "request": {
+        "method": "POST",
+        "urlPath": "/session",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-success"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "session-id": "ABADCAFE"
+        }
+      }
+    },
+    {
+      "scenarioName": "Address",
+      "requiredScenarioState": "PostcodeLookup",
       "newScenarioState": "AddressResponses",
       "request": {
         "method": "GET",
@@ -29,15 +49,15 @@
         "jsonBody": [
           {
             "buildingNumber": "1",
-            "postTown": "TESTTOWN",
-            "postcode": "TE5T1NG",
-            "streetName": "TEST STREET"
+            "addressLocality": "LONDON",
+            "postalCode": "E1 8QS",
+            "streetName": "WHITECHAPEL HIGH STREET"
           },
           {
-            "buildingNumber": "2A",
-            "postTown": "TESTTOWN",
-            "postcode": "TE5T1NG",
-            "streetName": "TEST STREET"
+            "buildingNumber": "10",
+            "addressLocality": "LONDON",
+            "postalCode": "E1 8QS",
+            "streetName": "WHITECHAPEL HIGH STREET"
           }
         ]
       }
@@ -51,7 +71,8 @@
         "url": "/postcode-lookup/XXX_XX",
         "headers": {
           "x-scenario-id": {
-            "equalTo": "address-success"
+            "equalTo": "address-success",
+            "absent": false
           }
         }
       },
@@ -78,20 +99,20 @@
         "jsonBody": [
           {
             "buildingNumber": "1",
-            "postTown": "TESTTOWN",
+            "addressLocality": "TESTTOWN",
             "postcode": "PR3VC0DE",
             "streetName": "TEST STREET"
           },
           {
             "buildingNumber": "2A",
-            "postTown": "TESTTOWN",
-            "postcode": "PR3VC0DE",
+            "addressLocality": "TESTTOWN",
+            "postalCode": "PR3VC0DE",
             "streetName": "TEST STREET"
           },
           {
             "buildingNumber": "3A",
-            "postTown": "TESTTOWN",
-            "postcode": "PR3VC0DE",
+            "addressLocality": "TESTTOWN",
+            "postalCode": "PR3VC0DE",
             "streetName": "TEST STREET"
           }
         ]
@@ -113,11 +134,9 @@
       "response": {
         "status": 201,
         "jsonBody": {
-          "data": {
             "code": "mySuperSecretCode",
             "state": "myAwesomeState",
             "redirect_uri": "http://localhost:8085/callback"
-          }
         }
       }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This uses a Docker image to spin up a locally configured core-stub with a wiremock server and an address-front from a local Dockerfile.

The mocked data has been adjusted to match live data so that the tests can be run against live or mocked data transparently.

### What changed

- Added a docker-compose configuration
- Added config for standalone core-stub
- Changed urls to use environment variables
- 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-336](https://govukverify.atlassian.net/browse/KBV-336)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
