### PR TITLE
KBV-343-handle-redirect-url

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -36,6 +36,7 @@ class AddressConfirmController extends BaseController {
         req.session.tokenId
       );
       super.saveValues(req, res, () => {
+        req.sessionModel.set("redirect_url", data.redirect_uri);
         if (!data.code) {
           const error = {
             code: "server_error",

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -76,6 +76,9 @@ describe("Address confirmation controller", () => {
         session_id: sessionId,
       },
     });
+    expect(req.session.test.redirect_url).to.be.equal(
+      testData.addressApiResponse.data.redirect_uri
+    );
     expect(req.session.test.authorization_code).to.be.equal(
       testData.addressApiResponse.data.code
     );

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -38,22 +38,25 @@ module.exports = {
   redirectToCallback: async (req, res, next) => {
     try {
       const authCode = req.session["hmpo-wizard-address"].authorization_code;
-
-      const url = new URL(req.session.authParams.redirect_uri);
+      const url = req.session["hmpo-wizard-address"].redirect_url;
+      const redirectUrl = new URL(url);
 
       if (!authCode) {
         const error = req.session["hmpo-wizard-address"].error;
         const errorCode = error?.code;
         const errorDescription = error?.description ?? error?.message;
 
-        url.searchParams.append("error", errorCode);
-        url.searchParams.append("error_description", errorDescription);
+        redirectUrl.searchParams.append("error", errorCode);
+        redirectUrl.searchParams.append("error_description", errorDescription);
       } else {
-        url.searchParams.append("client_id", req.session.authParams.client_id);
-        url.searchParams.append("state", req.session.authParams.state);
-        url.searchParams.append("code", authCode);
+        redirectUrl.searchParams.append(
+          "client_id",
+          req.session.authParams.client_id
+        );
+        redirectUrl.searchParams.append("state", req.session.authParams.state);
+        redirectUrl.searchParams.append("code", authCode);
       }
-      res.redirect(url.toString());
+      res.redirect(redirectUrl.toString());
     } catch (e) {
       next(e);
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Save the redirect url with the token response then redirect to it at the end of the journey

### Why did it change

The redirect URL is embedded within the encrypted JWT, so the frontend will receive a URL from the BE after the JWT has been decrypted.


### Issue tracking

- [KBV-343](https://govukverify.atlassian.net/browse/KBV-343)
