### PR TITLE
KBV-366-update-address-confirm-page

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -15,13 +15,14 @@ class AddressConfirmController extends BaseController {
         return this.formatAddress(address);
       });
 
+
       const currentAddress = addresses.shift();
 
-      locals.formattedAddress = currentAddress;
+      const previousAddress = addresses.shift();
 
-      if (addresses.length) {
-        locals.previousAddresses = addresses;
-      }
+      locals.currentAddressRowValue = currentAddress.text;
+      locals.yearMovedRowValue = currentAddress.addressValidFrom;
+      locals.previousAddressRowValue = previousAddress?.text;
 
       callback(null, locals);
     });
@@ -63,7 +64,8 @@ class AddressConfirmController extends BaseController {
       buildingNameNumber = address.buildingName || address.buildingNumber;
     }
 
-    return `${buildingNameNumber}<br>${address.streetName},<br>${address.addressLocality},<br>${address.postalCode}<br>`;
+    const text = `${buildingNameNumber}<br>${address.streetName},<br>${address.addressLocality},<br>${address.postalCode}<br>`;
+    return { ...address, text };
   }
 
   async saveAddressess(axios, addresses, sessionId) {

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -34,7 +34,7 @@ describe("Address confirmation controller", () => {
   let addressConfirm;
 
   beforeEach(() => {
-    addresses = addressFactory(3);
+    addresses = addressFactory(2);
     req.sessionModel.set("addresses", addresses);
     addressConfirm = new AddressConfirmController({ route: "/test" });
   });
@@ -57,9 +57,11 @@ describe("Address confirmation controller", () => {
     });
 
     const currentAddress = formattedAddresses.shift();
+    const previousAddress = formattedAddresses.shift();
     const params = {
-      formattedAddress: currentAddress,
-      previousAddresses: formattedAddresses,
+      currentAddressRowValue: currentAddress,
+      yearMovedRowValue: undefined, // todo empty until year from is implemented.
+      previousAddressRowValue: previousAddress,
     };
 
     addressConfirm.locals(req, res, next);

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -34,3 +34,9 @@ address-year-from:
   title: What year did you start living at this address?
   classes: govuk-input--width-4
   label: Year
+
+address-confirm:
+  current: Current address
+  year-current: Year moved in to current address
+  previous: Previous address
+  change: Change

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -22,9 +22,9 @@ address-results:
     - <b>{{values.address-search}}</b> <a href="/postcode">Change</a>
 
 address-confirm:
-  title: Check your address details
+  title: Check your details
   warning:
-      - Make sure your details are correct before you continue. You won't be able to change it later.
+      - Make sure your details are correct before you continue. You will not be able to change them later.
   current: Current address
   previous: Previous address
 

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -1,6 +1,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "hmpo-html/macro.njk" import hmpoHtml %}
 {% from "hmpo-submit/macro.njk" import hmpoSubmit %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% extends "form-template.njk" %}
 {% set hmpoPageKey = "address-confirm" %}
@@ -14,24 +15,98 @@
     iconFallbackText: "Warning"
   }) }}
 
-  <h3>{{translate("pages.address-confirm.current")}}</h3>
+  {% if previousAddressRowValue %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: translate("fields.address-confirm.current")
+          },
+          value: {
+            html: currentAddressRowValue
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: translate("fields.address-confirm.change")
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: translate("fields.address-confirm.year-current")
+          },
+          value: {
+            text: yearMovedRowValue
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: translate("fields.address-confirm.change")
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: translate("fields.address-confirm.previous")
+          },
+          value: {
+            html: previousAddressRowValue
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: translate("fields.address-confirm.change")
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
 
-    {{hmpoHtml(formattedAddress)}}
-    <p>{{hmpoHtml(translate("links.changeAddress"))}}</p>
-  </span>
+  {% else %}
 
-  <br>
-
-  {% if previousAddresses %}
-    <hr>
-    <h3>{{translate("pages.address-confirm.previous")}}</h3>
-    {% for address in previousAddresses %}
-
-        {{hmpoHtml(address)}}
-      </span>
-      <hr>
-
-    {% endfor %}
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: translate("fields.address-confirm.current")
+          },
+          value: {
+            html: currentAddressRowValue
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: translate("fields.address-confirm.change")
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: translate("fields.address-confirm.year-current")
+          },
+          value: {
+            text: yearMovedRowValue
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: translate("fields.address-confirm.change")
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
 
   {% endif %}
 


### PR DESCRIPTION
## Proposed changes

### What changed

changes to the design of the address confirm page to use the govuk summary component.
These changes are in a list of design changes. Additional logic changes are to come.

### Why did it change

Align with design changes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-366](https://govukverify.atlassian.net/browse/KBV-366)

<img width="824" alt="image" src="https://user-images.githubusercontent.com/8826525/166493957-4c2ebfb2-8913-4c29-a063-806713aadf26.png">
