### PR TITLE
KBV-367-update-search-page-to-align-with-design

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -1,9 +1,9 @@
 
 buttons:
   next: Continue
-  select-address: Select Address
+  select-address: Select address
   cancel: Cancel
-  address-search: Find address
+  find-address: Find address
 govuk:
   serviceName: Prove your identity
   backLink: Back

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -3,7 +3,6 @@ address-form:
 
 address-search:
   label: Postcode
-  classes: govuk-input--width-8
   hint: For example, SW12 2AA
 
 address-results:

--- a/src/views/address/search.html
+++ b/src/views/address/search.html
@@ -1,3 +1,27 @@
 {% extends "form-template.njk" %}
 {% set hmpoPageKey = "address-search" %}
 {% set hmpoPageContent = "address-search" %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
+{% from "hmpo-select/macro.njk" import hmpoSelect %}
+{% from "hmpo-text/macro.njk" import hmpoText %}
+
+{% block mainContent %}
+
+  <h1 id="header">{{translate("pages.address-search.title")}} </h1>
+  {% call hmpoForm(ctx) %}
+
+    {{ hmpoText(ctx, {
+      id: "address-search",
+      label: {
+        key: translate(fields.address-search.label),
+        classes: "govuk-label govuk-label--m"
+      },
+      classes: "govuk-!-width-one-half",
+      hint:  translate("fields.address-search.hint")
+    }) }}
+
+    {{ hmpoSubmit(ctx, {text: translate("buttons.find-address")}) }}
+
+  {% endcall %}
+
+{% endblock %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Align search page with designs. Need to override the form main content for the custom text on the buttons.

### Why did it change

Align with design

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-367](https://govukverify.atlassian.net/browse/KBV-367)

<img width="635" alt="image" src="https://user-images.githubusercontent.com/8826525/166501503-94659224-e8fd-4b72-a311-3d57850285cc.png">

