### PR TITLE
KBV-368-update-error-handling-for-postcodes

### DIFF
--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -1,3 +1,10 @@
+const {
+  postcodeLength,
+  alphaNumeric,
+  missingAlphaOrNumeric,
+  isUkPostcode,
+} = require("./validators/postcodeValidator");
+
 module.exports = {
   "address-line-1": {
     type: "text",
@@ -22,17 +29,31 @@ module.exports = {
   "address-search": {
     type: "text",
     autocomplete: "Postcode",
+    formatter: [
+      {
+        type: "removeSpaces",
+        fn: (val) => val.replace(/\s+/g, ""),
+      },
+    ],
     validate: [
       {
         type: "required",
       },
       {
-        type: "minlength",
-        arguments: [5],
+        type: "postcodeLength",
+        fn: postcodeLength,
       },
       {
-        type: "maxlength",
-        arguments: [8],
+        type: "alphaNumeric",
+        fn: alphaNumeric,
+      },
+      {
+        type: "missingNumericOrAlpha",
+        fn: missingAlphaOrNumeric,
+      },
+      {
+        type: "isUkPostcode",
+        fn: isUkPostcode,
       },
     ],
   },

--- a/src/app/address/validators/postcodeValidator.js
+++ b/src/app/address/validators/postcodeValidator.js
@@ -1,0 +1,24 @@
+module.exports = {
+  postcodeLength: function (val) {
+    return val.length >= 5 && val.length <= 7;
+  },
+  alphaNumeric: function (val) {
+    return !!val.match(/^[a-z0-9]+$/i);
+  },
+  missingAlphaOrNumeric: function (val) {
+    if (val.match(/^[A-Za-z]+$/)) {
+      return false; // missing numbers
+    } else if (val.match(/^[0-9]+$/)) {
+      return false; // missing alphas
+    } else {
+      return true;
+    }
+  },
+  isUkPostcode: function (val) {
+    // taken from https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Validation
+    const ukPostcodeRegex =
+      /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/i;
+
+    return val.match(ukPostcodeRegex) ? true : false;
+  },
+};

--- a/src/app/address/validators/postcodeValidator.test.js
+++ b/src/app/address/validators/postcodeValidator.test.js
@@ -1,0 +1,70 @@
+const {
+  postcodeLength,
+  alphaNumeric,
+  missingAlphaOrNumeric,
+  isUkPostcode,
+} = require("./postcodeValidator");
+
+const validPostcodes = ["E18QS", "PA296YP"];
+const invalidPostcodeLength = ["1", "88888888", "4444", ""];
+const invalidAlphaOnly = ["abcde", "VXYZ", "AbCdEf"];
+const invalidIntOnly = ["11111", "123456", "000000"];
+const invalidSpecialChars = ["******", "E18Q%", "|/~_+!@"];
+const nonUkPostcodes = ["M1E1P5", "V9A2R3", "1A1B2B"]; // Canadian include alphanumeric data.
+
+describe("Postcode validator", () => {
+  describe("postcodeLength", () => {
+    it("should pass with valid length postcodes", () => {
+      const results = validPostcodes.map(postcodeLength);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail when invalid length postcodes", () => {
+      const results = invalidPostcodeLength.map(postcodeLength);
+      results.forEach((val) => {
+        expect(val).to.equal(false);
+      });
+    });
+  });
+
+  describe("alphaNumeric", () => {
+    it("should pass with valid postcodes", () => {
+      const results = validPostcodes.map(alphaNumeric);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail with invalid postcodes", () => {
+      const results = invalidSpecialChars.map(alphaNumeric);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+
+  describe("missingAlphaOrNumeric", () => {
+    it("should pass with valid postcodes", () => {
+      const results = validPostcodes.map(missingAlphaOrNumeric);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail with only alpha characters", () => {
+      const results = invalidAlphaOnly.map(missingAlphaOrNumeric);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+
+    it("should fail with only numeric characters", () => {
+      const results = invalidIntOnly.map(missingAlphaOrNumeric);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+
+  describe("isUkPostcode", () => {
+    it("should pass with valid postcodes", () => {
+      const results = validPostcodes.map(isUkPostcode);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail with invalid postcodes", () => {
+      const results = nonUkPostcodes.map(isUkPostcode);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+});

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -18,8 +18,10 @@ links:
   cantFindAddress:
     - <p><a href="/address/edit">I cannot find my address in the list</a></p>
 validation:
-  required: Please enter a {{label}}.
-  maxlength: 'Maximum length of  the {{label}} should be 8'
-  minlength: 'Minimum length of the {{label}} should be 5'
+  required: Enter a {{label}}.
+  postcodeLength: 'Your {{label}} should be between 5 and 7 characters'
+  alphaNumeric: 'Your {{label}} should only include numbers and letters'
+  missingNumericOrAlpha: 'Your {{label}} should include numbers and letters'
+  isUkPostcode: 'Enter a UK postcode'
   default: You must answer this question.
 


### PR DESCRIPTION
Add formatting rules for postcode

## Proposed changes

### What changed

Added validation rules for postcode entry.

### Why did it change

We need to include user friendly postcode error messaging. 

### Issue tracking

- [KBV-368](https://govukverify.atlassian.net/browse/KBV-368)

## Checklists
- [x] Unit tests
- [ ] Browser tests
