### PR TITLE
KBV 371 add validation to manual address fields

### DIFF
--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -11,7 +11,7 @@ class AddressController extends BaseController {
         locals.addressHouseNumber = address.buildingNumber;
         locals.addressHouseName = address.buildingName;
         locals.addressStreetName = address.streetName;
-        locals.addressTownOrCity = address.addressLocality;
+        locals.addressLocality = address.addressLocality;
       }
       callback(null, locals);
     });
@@ -40,14 +40,14 @@ class AddressController extends BaseController {
     const addressHouseNumber = reqBody.addressHouseNumber || null;
     const addressHouseName = reqBody.addressHouseName || null;
     const addressStreetName = reqBody.addressStreetName;
-    const addressTownOrCity = reqBody.addressTownOrCity;
+    const addressLocality = reqBody.addressLocality;
     // const addressValidFrom = reqBody.addressValidFrom; // todo
 
     const address = {
       buildingNumber: addressFlatNumber || addressHouseNumber,
       buildingName: addressHouseName,
       streetName: addressStreetName,
-      addressLocality: addressTownOrCity,
+      addressLocality,
     };
 
     return address;

--- a/src/app/address/controllers/address.test.js
+++ b/src/app/address/controllers/address.test.js
@@ -28,7 +28,7 @@ describe("address controller", () => {
       addressFlatNumber: "10a",
       addressHouseName: "My buildng name",
       addressStreetName: "street road",
-      addressTownOrCity: "small town",
+      addressLocality: "small town",
     };
 
     req.body = addressToSave;
@@ -42,7 +42,7 @@ describe("address controller", () => {
     );
     expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
     expect(savedAddress.addressLocality).to.equal(
-      addressToSave.addressTownOrCity
+      addressToSave.addressLocality
     );
     expect(savedAddress.buildingName).to.equal(addressToSave.addressHouseName);
   });
@@ -51,7 +51,7 @@ describe("address controller", () => {
     const addressToSave = {
       addressHouseNumber: "10a",
       addressStreetName: "street road",
-      addressTownOrCity: "small town",
+      addressLocality: "small town",
     };
 
     req.body = addressToSave;
@@ -65,7 +65,7 @@ describe("address controller", () => {
     );
     expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
     expect(savedAddress.addressLocality).to.equal(
-      addressToSave.addressTownOrCity
+      addressToSave.addressLocality
     );
   });
 
@@ -74,7 +74,7 @@ describe("address controller", () => {
       addressFlatNumber: "1a",
       addressHouseName: "My building",
       addressStreetName: "avenue",
-      addressTownOrCity: "large town",
+      addressLocality: "large town",
     };
 
     const existingAddresses = [
@@ -99,8 +99,6 @@ describe("address controller", () => {
     expect(existingAddress).to.be.equal(existingAddresses[0]);
     expect(newAddress.buildingNumber).to.equal(addressToSave.addressFlatNumber);
     expect(newAddress.streetName).to.equal(addressToSave.addressStreetName);
-    expect(newAddress.addressLocality).to.equal(
-      addressToSave.addressTownOrCity
-    );
+    expect(newAddress.addressLocality).to.equal(addressToSave.addressLocality);
   });
 });

--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -8,10 +8,10 @@ const {
 
 class AddressSearchController extends BaseController {
   async saveValues(req, res, callback) {
-    const addressPostcode = req.body["address-search"];
+    const addressPostcode = req.body["addressSearch"];
 
     try {
-      const addressPostcode = req.body["address-search"];
+      const addressPostcode = req.body["addressSearch"];
       const searchResults = await this.search(
         req.axios,
         addressPostcode,

--- a/src/app/address/controllers/addressSearch.test.js
+++ b/src/app/address/controllers/addressSearch.test.js
@@ -42,7 +42,7 @@ describe("Address Search controller", () => {
   it("Should call api with a postcode and save results to session", async () => {
     const testPostcode = "myPostcode";
     req.axios.get = sinon.fake.returns(testData.apiResponse);
-    req.body["address-search"] = testPostcode;
+    req.body["addressSearch"] = testPostcode;
 
     await addressSearch.saveValues(req, res, next);
 
@@ -74,7 +74,7 @@ describe("Address Search controller", () => {
   it("Should not throw an error when api throws error", async () => {
     const testPostcode = "myPostcode";
     req.axios.get = sinon.fake.rejects();
-    req.body["address-search"] = testPostcode;
+    req.body["addressSearch"] = testPostcode;
 
     await addressSearch.saveValues(req, res, next);
 

--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -6,7 +6,7 @@ const {
 } = require("./validators/postcodeValidator");
 
 module.exports = {
-  "address-search": {
+  addressSearch: {
     type: "text",
     autocomplete: "Postcode",
     formatter: [

--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -5,6 +5,11 @@ const {
   isUkPostcode,
 } = require("./validators/postcodeValidator");
 
+const {
+  alphaNumericWithSpecialChars,
+  isPreviousYear,
+} = require("./validators/addressValidator");
+
 module.exports = {
   addressSearch: {
     type: "text",
@@ -34,6 +39,97 @@ module.exports = {
       {
         type: "isUkPostcode",
         fn: isUkPostcode,
+      },
+    ],
+  },
+  addressFlatNumber: {
+    type: "text",
+    validate: [
+      {
+        type: "maxlength",
+        fn: "maxlength",
+        arguments: [30],
+      },
+      {
+        type: "alphaNumericWithSpecialChars",
+        fn: alphaNumericWithSpecialChars,
+      },
+    ],
+  },
+  addressHouseNumber: {
+    type: "text",
+    validate: [
+      {
+        type: "maxlength",
+        fn: "maxlength",
+        arguments: [10],
+      },
+      {
+        type: "alphaNumericWithSpecialChars",
+        fn: alphaNumericWithSpecialChars,
+      },
+    ],
+  },
+  addressHouseName: {
+    type: "text",
+    validate: [
+      {
+        type: "maxlength",
+        fn: "maxlength",
+        arguments: [50],
+      },
+      {
+        type: "alphaNumericWithSpecialChars",
+        fn: alphaNumericWithSpecialChars,
+      },
+    ],
+  },
+  addressStreetName: {
+    type: "text",
+    validate: [
+      {
+        type: "required",
+      },
+      {
+        type: "maxlength",
+        fn: "maxlength",
+        arguments: [60],
+      },
+      {
+        type: "alphaNumericWithSpecialChars",
+        fn: alphaNumericWithSpecialChars,
+      },
+    ],
+  },
+  addressLocality: {
+    type: "text",
+    validate: [
+      {
+        type: "required",
+      },
+      {
+        type: "maxlength",
+        fn: "maxlength",
+        arguments: [60],
+      },
+      {
+        type: "alphaNumericWithSpecialChars",
+        fn: alphaNumericWithSpecialChars,
+      },
+    ],
+  },
+  addressYearFrom: {
+    type: "number",
+    validate: [
+      {
+        type: "required",
+      },
+      {
+        type: "date-year",
+      },
+      {
+        type: "isPreviousDate",
+        fn: isPreviousYear,
       },
     ],
   },

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   "/search": {
     controller: search,
-    fields: ["address-search"],
+    fields: ["addressSearch"],
     next: [
       {
         field: "requestIsSuccessful",
@@ -51,7 +51,7 @@ module.exports = {
   },
   "/previous": {
     controller: search,
-    fields: ["address-search"],
+    fields: ["addressSearch"],
     next: [
       {
         field: "requestIsSuccessful",

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -33,6 +33,14 @@ module.exports = {
     controller: address,
     editable: true,
     continueOnEdit: true,
+    fields: [
+      "addressFlatNumber",
+      "addressHouseNumber",
+      "addressHouseName",
+      "addressStreetName",
+      "addressLocality",
+      "addressYearFrom",
+    ],
     next: "confirm",
   },
   "/confirm": {

--- a/src/app/address/validators/addressValidator.js
+++ b/src/app/address/validators/addressValidator.js
@@ -1,0 +1,11 @@
+module.exports = {
+  alphaNumericWithSpecialChars: function (val) {
+    if (!val) {
+      return true; // handle when field is optional
+    }
+    return !!val.match(/^[0-9A-Z'\\/* -]+$/i);
+  },
+  isPreviousYear: function (val) {
+    return new Date(val).getFullYear() <= new Date().getFullYear();
+  },
+};

--- a/src/app/address/validators/addressValidator.test.js
+++ b/src/app/address/validators/addressValidator.test.js
@@ -1,0 +1,50 @@
+const {
+  alphaNumericWithSpecialChars,
+  isPreviousYear,
+} = require("./addressValidator");
+
+const today = new Date();
+const nextYear = String(today.getFullYear() + 1);
+const validInput = ["1a", "White Chapel", "Aldgate High Street", "London"];
+
+const validYears = [
+  "2021",
+  "2010",
+  "1970",
+  "0000",
+  String(today.getFullYear()),
+];
+
+const invalidInput = ["()%&^5$£@!|", "BadFlatNumber%"];
+const invalidFutureYears = ["2030", nextYear];
+
+describe("Address validator", () => {
+  describe("alphaNumericWithSpecialChars", () => {
+    it("should return true when empty string is passed", () => {
+      const result = alphaNumericWithSpecialChars("");
+      expect(result).to.equal(true);
+    });
+
+    it("should pass when valid strings are passed", () => {
+      const results = validInput.map(alphaNumericWithSpecialChars);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should fail when invalid strings are passed", () => {
+      const results = invalidInput.map(alphaNumericWithSpecialChars);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+
+  describe("isPreviousDate", () => {
+    it("should pass with valid dates", () => {
+      const results = validYears.map(isPreviousYear);
+      results.forEach((val) => expect(val).to.equal(true));
+    });
+
+    it("should pass with valid dates", () => {
+      const results = invalidFutureYears.map(isPreviousYear);
+      results.forEach((val) => expect(val).to.equal(false));
+    });
+  });
+});

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -23,5 +23,6 @@ validation:
   alphaNumeric: 'Your {{label}} should only include numbers and letters'
   missingNumericOrAlpha: 'Your {{label}} should include numbers and letters'
   isUkPostcode: 'Enter a UK postcode'
+  alphaNumericWithSpecialChars: Your {{ label }} should not include any special characters or symbols
   default: You must answer this question.
 

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,7 +1,7 @@
 address-form:
   label: What is your address?
 
-address-search:
+addressSearch:
   label: Postcode
   hint: For example, SW12 2AA
 

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -5,34 +5,41 @@ addressSearch:
   label: Postcode
   hint: For example, SW12 2AA
 
-address-results:
-  label: Select an address
-
-address-line-flat:
+addressFlatNumber:
   label: Flat number
+  validation:
+    maxlength: Check you've entered your flat number correctly
 
-address-line-house:
+addressHouseNumber:
   label: House number
+  validation:
+    maxlength: Check you've entered your house number correctly
 
-address-line-house-name:
+addressHouseName:
   label: House name
+  validation:
+    maxlength: Check you've entered your house name correctly
 
-address-line-street:
+addressStreetName:
   label: Street name
+  validation:
+    maxlength: Check you've entered your street name correctly
 
-address-town:
+addressLocality:
   label: Town or city
+  validation:
+    maxlength: Check you've entered your town or city correctly
 
-address-county:
-  label: County
-
-address-postcode:
-  label: Postcode
-
-address-year-from:
+addressYearFrom:
   title: What year did you start living at this address?
   classes: govuk-input--width-4
   label: Year
+  validation:
+    default: Enter a valid date
+    isPreviousDate: The date you moved into this address must be in the past
+
+address-results:
+  label: Select an address
 
 address-confirm:
   current: Current address

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -9,7 +9,7 @@ address:
 done:
   title: Done
 
-address-search:
+addressSearch:
   title: What is your current home address?
 
 address-previous:
@@ -19,7 +19,7 @@ address-results:
   title: What is your current home address?
   content:
     - Postcode
-    - <b>{{values.address-search}}</b> <a href="/postcode">Change</a>
+    - <b>{{values.addressSearch}}</b> <a href="/postcode">Change</a>
 
 address-confirm:
   title: Check your details

--- a/src/views/address/address.html
+++ b/src/views/address/address.html
@@ -23,7 +23,7 @@
     {{ govukInput({
       id: "addressFlatNumber",
       name: "addressFlatNumber",
-      label: { text: translate("fields.address-line-flat.label") },
+      label: { text: translate("fields.addressFlatNumber.label") },
       classes: "govuk-input--width-5",
       value: addressFlatNumber
     }) }}
@@ -31,7 +31,7 @@
     {{ govukInput({
       id: "addressHouseNumber",
       name: "addressHouseNumber",
-      label: { text: translate("fields.address-line-house.label") },
+      label: { text: translate("fields.addressHouseNumber.label") },
       classes: "govuk-input--width-5",
       value: addressHouseNumber
     }) }}
@@ -39,7 +39,7 @@
     {{ govukInput({
       id: "addressHouseName",
       name: "addressHouseName",
-      label: { text: translate("fields.address-line-house-name.label") },
+      label: { text: translate("fields.addressHouseName.label") },
       classes: "govuk-input--width-20",
       value: addressHouseName
     }) }}
@@ -47,27 +47,27 @@
     {{ govukInput({
       id: "addressStreetName",
       name: "addressStreetName",
-      label: { text: translate("fields.address-line-street.label") },
+      label: { text: translate("fields.addressStreetName.label") },
       classes: "govuk-input--width-20",
       value: addressStreetName
     }) }}
 
     {{ govukInput({
-      id: "addressTownOrCity",
-      name: "addressTownOrCity",
-      label: { text: translate("fields.address-town.label") },
+      id: "addressLocality",
+      name: "addressLocality",
+      label: { text: translate("fields.addressLocality.label") },
       classes: "govuk-input--width-20",
-      value: addressTownOrCity
+      value: addressLocality
     }) }}
 
-    <h4>{{translate("fields.address-year-from.title")}}</h4>
+    <h4>{{translate("fields.addressYearFrom.title")}}</h4>
 
     {{ govukInput({
-      id: "addressValidFrom",
-      name: "addressValidFrom",
-      label: { text: translate("fields.address-year-from.label") },
+      id: "addressYearFrom",
+      name: "addressYearFrom",
+      label: { text: translate("fields.addressYearFrom.label") },
       classes: "govuk-input--width-4",
-      value: addressValidFrom
+      value: addressYearFrom
     }) }}
 
     {{ hmpoSubmit(ctx, {text: translate("buttons.next")}) }}

--- a/src/views/address/search.html
+++ b/src/views/address/search.html
@@ -1,23 +1,23 @@
 {% extends "form-template.njk" %}
-{% set hmpoPageKey = "address-search" %}
-{% set hmpoPageContent = "address-search" %}
+{% set hmpoPageKey = "addressSearch" %}
+{% set hmpoPageContent = "addressSearch" %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-select/macro.njk" import hmpoSelect %}
 {% from "hmpo-text/macro.njk" import hmpoText %}
 
 {% block mainContent %}
 
-  <h1 id="header">{{translate("pages.address-search.title")}} </h1>
+  <h1 id="header">{{translate("pages.addressSearch.title")}} </h1>
   {% call hmpoForm(ctx) %}
 
     {{ hmpoText(ctx, {
-      id: "address-search",
+      id: "addressSearch",
       label: {
-        key: translate(fields.address-search.label),
+        key: translate(fields.addressSearch.label),
         classes: "govuk-label govuk-label--m"
       },
       classes: "govuk-!-width-one-half",
-      hint:  translate("fields.address-search.hint")
+      hint:  translate("fields.addressSearch.hint")
     }) }}
 
     {{ hmpoSubmit(ctx, {text: translate("buttons.find-address")}) }}


### PR DESCRIPTION
## Proposed changes

### What changed

Add validation rules to the manual address page.

In this PR, it is mostly validation rules being added alongside tests. I also took the opportunity to do a tiny refactor of a variable name that was using snake case rather than camelCase... I suspect I may do more of that in the future.

### Why did it change

To reduce the number of mistakes when adding an address to the store, we've added a number of validation methods to stop the user when they're adding their details. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-371](https://govukverify.atlassian.net/browse/KBV-371)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

### Other considerations
