### PR TITLE
BAU: remove existing search value from session when entering the previous journey

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -37,6 +37,8 @@ class AddressConfirmController extends BaseController {
     try {
       const moreInfoRequired = req.body.moreInfoRequired;
       if (moreInfoRequired) {
+        // reset variables specific to current address journey
+        req.sessionModel.set("addressSearch", null);
         req.sessionModel.set("addPreviousAddresses", true);
         callback();
       } else {

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -105,6 +105,13 @@ describe("Address confirmation controller", () => {
         "Failed to retrieve authorization code"
       );
     });
+
+    it("Should reset journey wide variables and enter previous journey when more information is required", async () => {
+      req.body.moreInfoRequired = true;
+      await addressConfirm.saveValues(req, res, next);
+      expect(req.session.test.addressSearch).to.equal(null);
+      expect(req.session.test.addPreviousAddresses).to.equal(true);
+    });
   });
 
   describe("isMoreInfoRequired", () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Moving from current address to previous address we should reset the search value to show the user an empty address search page. 

### Why did it change

Makes it clearer to the user that they're entering a new address journey
