### PR TITLE
bugfix/revert-template-not-found-on-error-pages

### DIFF
--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,2 +1,2 @@
-{% extends "../templates/address-base.html" %}
+{% extends "hmpo-template.njk" %}
 {% set hmpoPageKey = "errors.error" %}

--- a/src/views/errors/page-not-found.html
+++ b/src/views/errors/page-not-found.html
@@ -1,2 +1,2 @@
-{% extends "../templates/address-base.html" %}
+{% extends "hmpo-template.njk" %}
 {% set hmpoPageKey = "errors.pageNotFound" %}

--- a/src/views/errors/session-ended.html
+++ b/src/views/errors/session-ended.html
@@ -1,2 +1,2 @@
-{% extends "../templates/address-base.html" %}
+{% extends "hmpo-template.njk" %}
 {% set hmpoPageKey = "errors.sessionEnded" %}


### PR DESCRIPTION
## Proposed changes

### What changed

revert what the error pages are extending from

### Why did it change

The error pages are currently extending from the new template created for the main form pages, this throws an error currently as the path is incorrect but also the template includes form specific actions that the error pages may not currently need. Until unhappy/error path work is completed, revert these changes back to the template they initially extended 
