### PR TITLE
BAU-Hook up the edit links across address views

### DIFF
--- a/src/app/address/controllers/address.test.js
+++ b/src/app/address/controllers/address.test.js
@@ -1,4 +1,5 @@
 const BaseController = require("hmpo-form-wizard").Controller;
+const { expect } = require("chai");
 const addressFactory = require("../../../../test/utils/addressFactory");
 const AddressController = require("./address");
 
@@ -24,55 +25,158 @@ describe("address controller", () => {
     expect(address).to.be.an.instanceOf(BaseController);
   });
 
-  it("should save the address into the session - flat example", async () => {
-    const addressToSave = {
-      addressFlatNumber: "10a",
-      addressHouseName: "My buildng name",
-      addressStreetName: "street road",
-      addressLocality: "small town",
-      addressYearFrom: "2022",
-    };
+  describe("locals", () => {
+    it("should only prepopulate postalcode if no address has been chosen", () => {
+      const generatedAddress = addressFactory(1);
+      req.sessionModel.set("addressPostcode", generatedAddress[0].postalCode);
 
-    req.body = addressToSave;
+      address.locals(req, res, next);
 
-    await address.saveValues(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(next).to.have.been.calledWith(null, {
+        addressPostcode: generatedAddress[0].postalCode,
+      });
+    });
 
-    const savedAddress = req.session.test.addresses[0];
-    expect(next).to.have.been.calledOnce;
-    expect(savedAddress.buildingNumber).to.equal(
-      addressToSave.addressFlatNumber
-    );
-    expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
-    expect(savedAddress.addressLocality).to.equal(
-      addressToSave.addressLocality
-    );
-    expect(savedAddress.buildingName).to.equal(addressToSave.addressHouseName);
+    it("should prepopulate with the chosen address when part of the standard route", () => {
+      const generatedAddress = addressFactory(1);
+      req.sessionModel.set("addressPostcode", generatedAddress[0].postalCode);
+
+      req.sessionModel.set("chosenAddress", generatedAddress[0]);
+
+      address.locals(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(next).to.have.been.calledWith(null, {
+        addressPostcode: generatedAddress[0].postalCode,
+        addressHouseNumber: generatedAddress[0].buildingNumber,
+        addressStreetName: generatedAddress[0].streetName,
+        addressLocality: generatedAddress[0].addressLocality,
+        addressYearFrom: Number(generatedAddress[0].validFrom),
+        addressFlatNumber: undefined,
+        addressHouseName: generatedAddress[0].buildingName,
+      });
+    });
+
+    it("should prepopulate with the previous address when in editing previous address route", () => {
+      const generatedAddress = addressFactory(2);
+      req.originalUrl = "/previous/address/edit";
+      req.sessionModel.set("addresses", generatedAddress);
+      address.locals(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(next).to.have.been.calledWith(null, {
+        addressPostcode: generatedAddress[1].postalCode,
+        addressHouseNumber: generatedAddress[1].buildingNumber,
+        addressHouseName: generatedAddress[1].buildingName,
+        addressStreetName: generatedAddress[1].streetName,
+        addressLocality: generatedAddress[1].addressLocality,
+        addressYearFrom: Number(generatedAddress[1].validFrom),
+        addressFlatNumber: generatedAddress[1].buildingNumber,
+      });
+    });
+
+    it("should prepopulate with the current address when in editing current address route", () => {
+      const generatedAddress = addressFactory(2);
+      req.originalUrl = "/address/edit";
+      req.sessionModel.set("addresses", generatedAddress);
+      address.locals(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(next).to.have.been.calledWith(null, {
+        addressPostcode: generatedAddress[0].postalCode,
+        addressHouseNumber: generatedAddress[0].buildingNumber,
+        addressHouseName: generatedAddress[0].buildingName,
+        addressStreetName: generatedAddress[0].streetName,
+        addressLocality: generatedAddress[0].addressLocality,
+        addressYearFrom: Number(generatedAddress[0].validFrom),
+        addressFlatNumber: undefined,
+      });
+    });
   });
 
-  it("should save the address into the session - house example", async () => {
-    const addressToSave = {
-      addressHouseNumber: "10a",
-      addressStreetName: "street road",
-      addressLocality: "small town",
-      addressYearFrom: "2022",
-    };
+  describe("saveValues", () => {
+    it("should save the address into the session - flat example", async () => {
+      const addressToSave = {
+        addressFlatNumber: "10a",
+        addressHouseName: "My buildng name",
+        addressStreetName: "street road",
+        addressLocality: "small town",
+        addressYearFrom: "2022",
+      };
 
-    req.body = addressToSave;
+      req.body = addressToSave;
 
-    await address.saveValues(req, res, next);
+      await address.saveValues(req, res, next);
 
-    const savedAddress = req.session.test.addresses[0];
-    expect(next).to.have.been.calledOnce;
-    expect(savedAddress.buildingNumber).to.equal(
-      addressToSave.addressHouseNumber
-    );
-    expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
-    expect(savedAddress.addressLocality).to.equal(
-      addressToSave.addressLocality
-    );
+      const savedAddress = req.session.test.addresses[0];
+      expect(next).to.have.been.calledOnce;
+      expect(savedAddress.buildingNumber).to.equal(
+        addressToSave.addressFlatNumber
+      );
+      expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
+      expect(savedAddress.addressLocality).to.equal(
+        addressToSave.addressLocality
+      );
+      expect(savedAddress.buildingName).to.equal(
+        addressToSave.addressHouseName
+      );
+    });
+
+    it("should save the address into the session - house example", async () => {
+      const addressToSave = {
+        addressHouseNumber: "10a",
+        addressStreetName: "street road",
+        addressLocality: "small town",
+        addressYearFrom: "2022",
+      };
+
+      req.body = addressToSave;
+
+      await address.saveValues(req, res, next);
+
+      const savedAddress = req.session.test.addresses[0];
+      expect(next).to.have.been.calledOnce;
+      expect(savedAddress.buildingNumber).to.equal(
+        addressToSave.addressHouseNumber
+      );
+      expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
+      expect(savedAddress.addressLocality).to.equal(
+        addressToSave.addressLocality
+      );
+    });
+
+    it("should append the address to the saved addresses", async () => {
+      const addressToSave = {
+        addressFlatNumber: "1a",
+        addressHouseName: "My building",
+        addressStreetName: "avenue",
+        addressLocality: "large town",
+        addressYearFrom: "2022",
+      };
+
+      const existingAddresses = addressFactory(1);
+      req.sessionModel.set("addresses", existingAddresses);
+
+      req.body = addressToSave;
+      req.originalUrl = "/previous/address";
+
+      await address.saveValues(req, res, next);
+
+      const savedAddresses = req.session.test.addresses;
+      const existingAddress = savedAddresses[0];
+      const newAddress = savedAddresses[1];
+
+      expect(next).to.have.been.calledOnce;
+      expect(existingAddress).to.be.equal(existingAddresses[0]);
+      expect(newAddress.buildingNumber).to.equal(
+        addressToSave.addressFlatNumber
+      );
+      expect(newAddress.streetName).to.equal(addressToSave.addressStreetName);
+      expect(newAddress.addressLocality).to.equal(
+        addressToSave.addressLocality
+      );
+    });
   });
 
-  it("should append the address to the saved addresses", async () => {
+  it("should overwrite the current address when current address already exists", async () => {
     const addressToSave = {
       addressFlatNumber: "1a",
       addressHouseName: "My building",
@@ -89,13 +193,54 @@ describe("address controller", () => {
     await address.saveValues(req, res, next);
 
     const savedAddresses = req.session.test.addresses;
-    const existingAddress = savedAddresses[0];
-    const newAddress = savedAddresses[1];
 
     expect(next).to.have.been.calledOnce;
-    expect(existingAddress).to.be.equal(existingAddresses[0]);
-    expect(newAddress.buildingNumber).to.equal(addressToSave.addressFlatNumber);
-    expect(newAddress.streetName).to.equal(addressToSave.addressStreetName);
-    expect(newAddress.addressLocality).to.equal(addressToSave.addressLocality);
+    expect(savedAddresses[0].buildingName).to.equal(
+      addressToSave.addressHouseName
+    );
+    expect(savedAddresses[0].buildingNumber).to.equal(
+      addressToSave.addressFlatNumber
+    );
+    expect(savedAddresses[0].addressLocality).to.equal(
+      addressToSave.addressLocality
+    );
+    expect(savedAddresses[0].addressStreetName).to.equal(
+      addressToSave.streetName
+    );
+  });
+
+  it("should overwrite the previous address when previous address already exists and in previous journey", async () => {
+    const addressToSave = {
+      addressFlatNumber: "1a",
+      addressHouseName: "My building",
+      addressStreetName: "avenue",
+      addressLocality: "large town",
+      addressYearFrom: "2022",
+    };
+
+    const existingAddresses = addressFactory(2);
+
+    req.sessionModel.set("addresses", existingAddresses);
+    req.originalUrl = "/previous/address/edit";
+    req.body = addressToSave;
+
+    await address.saveValues(req, res, next);
+
+    const savedAddresses = req.session.test.addresses;
+    const modifiedPreviousAddress = savedAddresses[1];
+    expect(next).to.have.been.calledOnce;
+
+    expect(modifiedPreviousAddress.buildingName).to.equal(
+      addressToSave.addressHouseName
+    );
+    expect(modifiedPreviousAddress.buildingNumber).to.equal(
+      addressToSave.addressFlatNumber
+    );
+    expect(modifiedPreviousAddress.addressLocality).to.equal(
+      addressToSave.addressLocality
+    );
+    expect(modifiedPreviousAddress.addressStreetName).to.equal(
+      addressToSave.streetName
+    );
   });
 });

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -32,6 +32,7 @@ module.exports = {
     controller: address,
     editable: true,
     continueOnEdit: true,
+    prereqs: ["/search"],
     fields: [
       "addressFlatNumber",
       "addressHouseNumber",
@@ -78,6 +79,7 @@ module.exports = {
     controller: address,
     editable: true,
     continueOnEdit: true,
+    prereqs: ["/previous/search"],
     fields: [
       "addressFlatNumber",
       "addressHouseNumber",

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -31,7 +31,7 @@
           actions: {
             items: [
               {
-                href: "#",
+                href: "/address/edit",
                 text: translate("fields.address-confirm.change")
               }
             ]
@@ -47,7 +47,7 @@
           actions: {
             items: [
               {
-                href: "#",
+                href: "/address/edit",
                 text: translate("fields.address-confirm.change")
               }
             ]
@@ -63,7 +63,7 @@
           actions: {
             items: [
               {
-                href: "#",
+                href: "/previous/address/edit",
                 text: translate("fields.address-confirm.change")
               }
             ]
@@ -86,7 +86,7 @@
           actions: {
             items: [
               {
-                href: "#",
+                href: "/address/edit",
                 text: translate("fields.address-confirm.change")
               }
             ]
@@ -102,7 +102,7 @@
           actions: {
             items: [
               {
-                href: "#",
+                href: "/address/edit",
                 text: translate("fields.address-confirm.change")
               }
             ]


### PR DESCRIPTION
## Proposed changes

### What changed

hooked up links to allow users to modify their addresses.
As part of the changes, I refactored how address view knows what address to pre-populate its fields. If the origin URL is a previous URL we should use the users previous address, else use the users current address or if they've arrived from the result page, use the chosen address.

### Why did it change

Design allow users to go back and change their address. These links needed to be hooked up to their relative steps.

