### PR TITLE
refactor: Move oauth properties from sessionModel to session.authParams

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -6,7 +6,7 @@ const {
   },
 } = require("../../../lib/config");
 
-const { addOAuthPropertiesToSessionModel } = require("../../../lib/oauth");
+const { addOAuthPropertiesToSession } = require("../../../lib/oauth");
 
 class AddressConfirmController extends BaseController {
   locals(req, res, callback) {
@@ -55,8 +55,8 @@ class AddressConfirmController extends BaseController {
           // if we're into save values we're finished with gathering addresses
           req.sessionModel.set("addPreviousAddresses", false);
 
-          addOAuthPropertiesToSessionModel({
-            sessionModel: req.sessionModel,
+          addOAuthPropertiesToSession({
+            authParams: req.session.authParams,
             data,
           });
 

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -24,6 +24,7 @@ beforeEach(() => {
   res = setup.res;
   next = setup.next;
   req.session.tokenId = sessionId;
+  req.session.authParams = {};
 });
 
 afterEach(() => {
@@ -83,13 +84,13 @@ describe("Address confirmation controller", () => {
           session_id: sessionId,
         },
       });
-      expect(req.session.test.redirect_url).to.be.equal(
+      expect(req.session.authParams.redirect_url).to.be.equal(
         testData.addressApiResponse.data.redirect_uri
       );
-      expect(req.session.test.authorization_code).to.be.equal(
+      expect(req.session.authParams.authorization_code).to.be.equal(
         testData.addressApiResponse.data.code
       );
-      expect(req.session.test.state).to.be.equal(
+      expect(req.session.authParams.state).to.be.equal(
         testData.addressApiResponse.data.state
       );
     });
@@ -100,8 +101,8 @@ describe("Address confirmation controller", () => {
       req.axios.put = sinon.fake.resolves(response);
 
       await addressConfirm.saveValues(req, res, next);
-      expect(req.session.test.error.code).to.be.equal("server_error");
-      expect(req.session.test.error.error_description).to.be.equal(
+      expect(req.session.authParams.error.code).to.be.equal("server_error");
+      expect(req.session.authParams.error.error_description).to.be.equal(
         "Failed to retrieve authorization code"
       );
     });

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -49,7 +49,6 @@ module.exports = {
   redirectToCallback: async (req, res, next) => {
     try {
       const redirectUrl = buildRedirectUrl({
-        sessionModel: req.session["hmpo-wizard-address"],
         authParams: req.session.authParams,
       });
 

--- a/src/app/oauth2/middleware.test.js
+++ b/src/app/oauth2/middleware.test.js
@@ -175,12 +175,9 @@ describe("oauth middleware", () => {
       req.session = {
         authParams: {
           client_id: clientId,
-        },
-        "hmpo-wizard-address": {
           authorization_code: code,
           redirect_url: redirect,
           state,
-          client_id: clientId,
         },
       };
 
@@ -196,12 +193,12 @@ describe("oauth middleware", () => {
     });
 
     it("should redirects with error when error present", async () => {
-      delete req.session["hmpo-wizard-address"].authorization_code;
+      delete req.session.authParams.authorization_code;
 
       const errorCode = "123";
       const description = "myDescription";
 
-      req.session["hmpo-wizard-address"].error = {
+      req.session.authParams.error = {
         code: errorCode,
         description: description,
       };
@@ -214,7 +211,7 @@ describe("oauth middleware", () => {
     });
 
     it("should call next with URL error if redirect_uri not present", async () => {
-      delete req.session["hmpo-wizard-address"].redirect_url;
+      delete req.session.authParams.redirect_url;
 
       await middleware.redirectToCallback(req, res, next);
 

--- a/src/lib/oauth.js
+++ b/src/lib/oauth.js
@@ -1,7 +1,7 @@
 module.exports = {
-  addOAuthPropertiesToSessionModel: ({ sessionModel, data } = {}) => {
-    sessionModel.set("redirect_url", data.redirect_uri);
-    sessionModel.set("state", data.state);
+  addOAuthPropertiesToSession: ({ authParams, data } = {}) => {
+    authParams.redirect_url = data.redirect_uri;
+    authParams.state = data.state;
 
     if (!data.code) {
       const error = {
@@ -9,20 +9,20 @@ module.exports = {
         error_description: "Failed to retrieve authorization code",
       };
 
-      sessionModel.set("error", error);
+      authParams.error = error;
     } else {
-      sessionModel.set("authorization_code", data.code);
+      authParams.authorization_code = data.code;
     }
   },
-  buildRedirectUrl: ({ sessionModel, authParams }) => {
-    const authCode = sessionModel.authorization_code;
-    const url = sessionModel.redirect_url;
-    const state = sessionModel.state;
+  buildRedirectUrl: ({ authParams }) => {
+    const authCode = authParams.authorization_code;
+    const url = authParams.redirect_url;
+    const state = authParams.state;
 
     let redirectUrl = new URL(url);
 
     if (!authCode) {
-      const error = sessionModel.error;
+      const error = authParams.error;
       const errorCode = error?.code;
       const errorDescription = error?.description ?? error?.message;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

OAuth params are now stored on the `req.session.authParams` object, instead of the `req.sessionModel`. This makes it more flexible and easier to use in a common way.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-397](https://govukverify.atlassian.net/browse/KBV-397)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
