### PR TITLE
bugfix: going from previous address to confirm removes the option to …

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -23,10 +23,9 @@ class AddressConfirmController extends BaseController {
       const yearFrom = new Date(currentAddress.validFrom).getFullYear();
       const today = new Date();
 
-      locals.addPreviousAddresses = !req.sessionModel.get(
-        "addPreviousAddresses"
-      );
-      locals.isMoreInfoRequirred = this.isMoreInfoRequired(yearFrom, today);
+      // if no previous addresses + more info is required, then radio button menu is rendered
+      locals.isMoreInfoRequirred =
+        this.isMoreInfoRequired(yearFrom, today) && !previousAddress;
       locals.currentAddressRowValue = currentAddress.text;
       locals.validFromRow = String(yearFrom);
       locals.previousAddressRowValue = previousAddress?.text;

--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -61,8 +61,7 @@ describe("Address confirmation controller", () => {
       const currentAddress = formattedAddresses.shift();
       const previousAddress = formattedAddresses.shift();
       const params = {
-        addPreviousAddresses: true,
-        isMoreInfoRequirred: true,
+        isMoreInfoRequirred: false, // not required as we already have a previous address
         currentAddressRowValue: currentAddress,
         validFromRow: String(new Date().getFullYear()),
         previousAddressRowValue: previousAddress,

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -115,7 +115,7 @@
 
   {% call hmpoForm(ctx) %}
 
-    {% if isMoreInfoRequirred and addPreviousAddresses %}
+    {% if isMoreInfoRequirred %}
       {{ govukRadios({
         classes: "govuk-radios--inline",
         id: "moreInfoRequired",


### PR DESCRIPTION
## Proposed changes

### What changed

Change the logic that shows the radio buttons which prompt for more information.

### Why did it change

Previous logic, would only show the button when the user hadn't been into the previous journey and when they triggered the more information logic.
This proves to be a problem when entering the previous address journey and then returning back to the confirmation page. A simple fix for this is to only show the radio buttons when we dont have any previous addresses and the validFrom value trips the more information logic. This way they should always end up seeing the radio button as long as they dont add an additional address and the date they provide is recent.
