### PR TITLE
bugfix: null valifrom date breaks previous addresses

### DIFF
--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -84,6 +84,10 @@ class AddressController extends BaseController {
       validFrom: addressYearFrom,
     };
 
+    if (isPreviousAddress) {
+      delete address.validFrom;
+    }
+
     return address;
   }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Changes in the address API have results in it not allowing null for valid from dates on previous addresses. So deleting the field when its added in the address.

### Why did it change

These changes where made to be able to save addresses in the backend