### PR TITLE
refactor: Use common config with express app.set / app.get

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,10 @@
 const setScenarioHeaders = require("./lib/scenario-headers");
 const setAxiosDefaults = require("./lib/axios");
 
-const { PORT, SESSION_SECRET, REDIS } = require("./lib/config");
+const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
+
+const { API, APP, PORT, SESSION_SECRET, REDIS } = require("./lib/config");
+
 const { setup } = require("hmpo-app");
 
 const loggerConfig = {
@@ -36,6 +39,14 @@ app.get("nunjucks").addGlobal("getContext", function () {
     ctx: this.ctx.ctx,
   };
 });
+
+setAPIConfig({
+  app,
+  baseUrl: API.BASE_URL,
+  authorizePath: API.PATHS.AUTHORIZE,
+});
+
+setOAuthPaths({ app, entryPointPath: APP.PATHS.ADDRESS });
 
 router.use(setScenarioHeaders);
 router.use(setAxiosDefaults);

--- a/src/app/oauth2/index.js
+++ b/src/app/oauth2/index.js
@@ -6,7 +6,7 @@ const {
   addAuthParamsToSession,
   redirectToCallback,
   initSessionWithJWT,
-  redirectToAddress,
+  redirectToEntryPoint,
   addJWTToRequest,
 } = require("./middleware");
 
@@ -15,7 +15,7 @@ router.get(
   addAuthParamsToSession,
   addJWTToRequest,
   initSessionWithJWT,
-  redirectToAddress
+  redirectToEntryPoint
 );
 router.get("/callback", redirectToCallback);
 

--- a/src/app/oauth2/middleware.js
+++ b/src/app/oauth2/middleware.js
@@ -1,12 +1,3 @@
-const {
-  API: {
-    PATHS: { AUTHORIZE },
-  },
-  APP: {
-    PATHS: { ADDRESS },
-  },
-} = require("../../lib/config");
-
 const { buildRedirectUrl } = require("../../lib/oauth");
 
 module.exports = {
@@ -30,10 +21,15 @@ module.exports = {
       return next(new Error("Missing client_id"));
     }
 
+    const authorizePath = req.app.get("API.PATHS.AUTHORIZE");
+    if (!authorizePath) {
+      return next(new Error("Missing API.PATHS.AUTHORIZE value"));
+    }
+
     const requestJWT = req.jwt;
     try {
       if (requestJWT) {
-        const apiResponse = await req.axios.post(AUTHORIZE, {
+        const apiResponse = await req.axios.post(authorizePath, {
           request: req.jwt,
           client_id: req.session.authParams.client_id,
         });
@@ -58,7 +54,12 @@ module.exports = {
     }
   },
 
-  redirectToAddress: async (req, res) => {
-    res.redirect(ADDRESS);
+  redirectToEntryPoint: async (req, res, next) => {
+    const entryPointPath = req.app.get("APP.PATHS.ENTRYPOINT");
+    if (!entryPointPath) {
+      return next(new Error("Missing APP.PATHS.ENTRYPOINT value"));
+    }
+
+    res.redirect(entryPointPath);
   },
 };

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -1,11 +1,14 @@
 const axios = require("axios");
-const {
-  API: { BASE_URL },
-} = require("./config");
 
 module.exports = function (req, res, next) {
+  const baseURL = req.app.get("API.BASE_URL");
+
+  if (!baseURL) {
+    next(new Error("Missing API.BASE_URL value"));
+  }
+
   req.axios = axios.create({
-    baseURL: BASE_URL,
+    baseURL,
   });
 
   if (req.scenarioIDHeader && req.axios?.defaults?.headers?.common) {

--- a/src/lib/axios.test.js
+++ b/src/lib/axios.test.js
@@ -1,14 +1,8 @@
 const proxyquire = require("proxyquire");
 
 let axiosStub = {};
-
 const axios = proxyquire("./axios", {
   axios: axiosStub,
-  "./config": {
-    API: {
-      BASE_URL: "http://example.net",
-    },
-  },
 });
 
 describe("axios", () => {
@@ -23,6 +17,11 @@ describe("axios", () => {
     req = setup.req;
     res = setup.res;
     next = setup.next;
+
+    req.app = {
+      get: sinon.stub(),
+    };
+    req.app.get.withArgs("API.BASE_URL").returns("http://example.net");
 
     axiosClient = {};
 

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,0 +1,10 @@
+module.exports = {
+  setAPIConfig: ({ app, baseUrl, authorizePath }) => {
+    app.set("API.BASE_URL", baseUrl);
+    app.set("API.PATHS.AUTHORIZE", authorizePath);
+  },
+
+  setOAuthPaths: ({ app, entryPointPath }) => {
+    app.set("APP.PATHS.ENTRYPOINT", entryPointPath);
+  },
+};

--- a/src/lib/settings.test.js
+++ b/src/lib/settings.test.js
@@ -1,0 +1,42 @@
+const { setAPIConfig, setOAuthPaths } = require("./settings");
+
+describe("settings", () => {
+  let app;
+
+  beforeEach(() => {
+    app = {
+      set: sinon.stub(),
+    };
+  });
+
+  describe("setAPIConfig", () => {
+    it("should set 'API.API_BASE_URL", () => {
+      setAPIConfig({ app, baseUrl: "http://example.com" });
+
+      expect(app.set).to.have.been.calledWith(
+        "API.BASE_URL",
+        "http://example.com"
+      );
+    });
+
+    it("should set 'API.PATHS.AUTHORIZE", () => {
+      setAPIConfig({ app, authorizePath: "/api/auth" });
+
+      expect(app.set).to.have.been.calledWith(
+        "API.PATHS.AUTHORIZE",
+        "/api/auth"
+      );
+    });
+  });
+
+  describe("setOAuthPaths", () => {
+    it("should set 'APP.PATHS.ENTRYPOINT", () => {
+      setOAuthPaths({ app, entryPointPath: "/website/subpath" });
+
+      expect(app.set).to.have.been.calledWith(
+        "APP.PATHS.ENTRYPOINT",
+        "/website/subpath"
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This is a bit of a big PR, but it is doing one thing - refactoring common code to use properties set via `express` `app.set('propertyname','propertyvalue')`.

The code to do set these properties can be invoked during server creation, as per `settings.js`.

At this point, all the code in `/app/oauth` can be moved into a common area.  All the code in `lib`, except for `config` and `settings` can also be moved over. These two files will be different for each credential issuer.

Missing tests have also been added.

Any thoughts on naming are welcome.
 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-397](https://govukverify.atlassian.net/browse/KBV-397)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
