### PR TITLE
BAU refactor to use HMPO Components over GovUK components 

### DIFF
--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -1,38 +1,38 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 
 class AddressController extends BaseController {
-  locals(req, res, callback) {
-    super.locals(req, res, (err, locals) => {
+  getValues(req, res, callback) {
+    super.getValues(req, res, (err, values) => {
       const addresses = req.sessionModel.get("addresses");
       let address;
 
       if (req.originalUrl === "/previous/address/edit") {
         // edit previous address
         address = addresses[1];
-        locals.addressPostcode = address.postalCode;
+        values.addressPostcode = address.postalCode;
       } else if (req.originalUrl === "/address/edit") {
         // edit current address
         address = addresses[0];
-        locals.addressPostcode = address.postalCode;
+        values.addressPostcode = address.postalCode;
       } else {
         // edit the chosen address
         address = req.sessionModel.get("chosenAddress");
-        locals.addressPostcode = req.sessionModel.get("addressPostcode");
+        values.addressPostcode = req.sessionModel.get("addressPostcode");
       }
 
       if (address) {
-        locals.addressFlatNumber = address.addressFlatNumber;
-        locals.addressHouseNumber = address.buildingNumber;
-        locals.addressHouseName = address.buildingName;
-        locals.addressStreetName = address.streetName;
-        locals.addressLocality = address.addressLocality;
+        values.addressFlatNumber = address.addressFlatNumber;
+        values.addressHouseNumber = address.buildingNumber;
+        values.addressHouseName = address.buildingName;
+        values.addressStreetName = address.streetName;
+        values.addressLocality = address.addressLocality;
 
         const yearFrom = address.validFrom
           ? new Date(address.validFrom).getFullYear()
           : null;
-        locals.addressYearFrom = yearFrom;
+        values.addressYearFrom = yearFrom;
       }
-      callback(null, locals);
+      callback(null, values);
     });
   }
 

--- a/src/app/address/controllers/address.test.js
+++ b/src/app/address/controllers/address.test.js
@@ -25,12 +25,12 @@ describe("address controller", () => {
     expect(address).to.be.an.instanceOf(BaseController);
   });
 
-  describe("locals", () => {
+  describe("getValues", () => {
     it("should only prepopulate postalcode if no address has been chosen", () => {
       const generatedAddress = addressFactory(1);
       req.sessionModel.set("addressPostcode", generatedAddress[0].postalCode);
 
-      address.locals(req, res, next);
+      address.getValues(req, res, next);
 
       expect(next).to.have.been.calledOnce;
       expect(next).to.have.been.calledWith(null, {
@@ -44,51 +44,58 @@ describe("address controller", () => {
 
       req.sessionModel.set("chosenAddress", generatedAddress[0]);
 
-      address.locals(req, res, next);
+      address.getValues(req, res, next);
       expect(next).to.have.been.calledOnce;
-      expect(next).to.have.been.calledWith(null, {
-        addressPostcode: generatedAddress[0].postalCode,
-        addressHouseNumber: generatedAddress[0].buildingNumber,
-        addressStreetName: generatedAddress[0].streetName,
-        addressLocality: generatedAddress[0].addressLocality,
-        addressYearFrom: Number(generatedAddress[0].validFrom),
-        addressFlatNumber: undefined,
-        addressHouseName: generatedAddress[0].buildingName,
-      });
+      expect(next).to.have.been.calledWith(
+        null,
+        sinon.match({
+          addressPostcode: generatedAddress[0].postalCode,
+          addressHouseNumber: generatedAddress[0].buildingNumber,
+          addressStreetName: generatedAddress[0].streetName,
+          addressLocality: generatedAddress[0].addressLocality,
+          addressYearFrom: Number(generatedAddress[0].validFrom),
+          addressHouseName: generatedAddress[0].buildingName,
+        })
+      );
     });
 
     it("should prepopulate with the previous address when in editing previous address route", () => {
       const generatedAddress = addressFactory(2);
       req.originalUrl = "/previous/address/edit";
       req.sessionModel.set("addresses", generatedAddress);
-      address.locals(req, res, next);
+      address.getValues(req, res, next);
       expect(next).to.have.been.calledOnce;
-      expect(next).to.have.been.calledWith(null, {
-        addressPostcode: generatedAddress[1].postalCode,
-        addressHouseNumber: generatedAddress[1].buildingNumber,
-        addressHouseName: generatedAddress[1].buildingName,
-        addressStreetName: generatedAddress[1].streetName,
-        addressLocality: generatedAddress[1].addressLocality,
-        addressYearFrom: Number(generatedAddress[1].validFrom),
-        addressFlatNumber: generatedAddress[1].buildingNumber,
-      });
+      expect(next).to.have.been.calledWith(
+        null,
+        sinon.match({
+          addressPostcode: generatedAddress[1].postalCode,
+          addressHouseNumber: generatedAddress[1].buildingNumber,
+          addressHouseName: generatedAddress[1].buildingName,
+          addressStreetName: generatedAddress[1].streetName,
+          addressLocality: generatedAddress[1].addressLocality,
+          addressYearFrom: Number(generatedAddress[1].validFrom),
+          addressFlatNumber: generatedAddress[1].buildingNumber,
+        })
+      );
     });
 
     it("should prepopulate with the current address when in editing current address route", () => {
       const generatedAddress = addressFactory(2);
       req.originalUrl = "/address/edit";
       req.sessionModel.set("addresses", generatedAddress);
-      address.locals(req, res, next);
+      address.getValues(req, res, next);
       expect(next).to.have.been.calledOnce;
-      expect(next).to.have.been.calledWith(null, {
-        addressPostcode: generatedAddress[0].postalCode,
-        addressHouseNumber: generatedAddress[0].buildingNumber,
-        addressHouseName: generatedAddress[0].buildingName,
-        addressStreetName: generatedAddress[0].streetName,
-        addressLocality: generatedAddress[0].addressLocality,
-        addressYearFrom: Number(generatedAddress[0].validFrom),
-        addressFlatNumber: undefined,
-      });
+      expect(next).to.have.been.calledWith(
+        null,
+        sinon.match({
+          addressPostcode: generatedAddress[0].postalCode,
+          addressHouseNumber: generatedAddress[0].buildingNumber,
+          addressHouseName: generatedAddress[0].buildingName,
+          addressStreetName: generatedAddress[0].streetName,
+          addressLocality: generatedAddress[0].addressLocality,
+          addressYearFrom: Number(generatedAddress[0].validFrom),
+        })
+      );
     });
   });
 

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -13,14 +13,14 @@ govuk:
 links:
   changeAddress: <a href="/address/edit" id="change-address">Change</a>
   changePostcode:
-    - <p>Postcode <br> <b>{{addressPostcode}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/search">Change</a></p>
+    - <p>Postcode <br> <b>{{values.addressPostcode}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/search">Change</a></p>
   cantFindAddress:
     - <p><a href="/address">I cannot find my address in the list</a></p>
   previous:
     changeAddress:
       - <a href="/previous/address/edit" id="change-address">Change</a>
     changePostcode:
-      - <p>Postcode <br> <b>{{addressPostcode}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/previous/search">Change</a></p>
+      - <p>Postcode <br> <b>{{values.addressPostcode}}</b> &nbsp;&nbsp;&nbsp;&nbsp; <a href="/previous/search">Change</a></p>
     cantFindAddress:
       - <p><a href="/previous/address">I cannot find my address in the list</a></p>
 validation:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -17,9 +17,6 @@ address-previous:
 
 address-results:
   title: What's your current home address?
-  content:
-    - Postcode
-    - <b>{{values.addressSearch}}</b> <a href="/postcode">Change</a>
 
 address-confirm:
   title: Check your details

--- a/src/views/address/components/address-input-fields.html
+++ b/src/views/address/components/address-input-fields.html
@@ -1,42 +1,37 @@
 
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "hmpo-text/macro.njk" import hmpoText %}
 
-{{ govukInput({
+{{ hmpoText(ctx, {
   id: "addressFlatNumber",
   name: "addressFlatNumber",
   label: { text: translate("fields.addressFlatNumber.label") },
-  classes: "govuk-input--width-5",
-  value: addressFlatNumber
+  classes: "govuk-input--width-5"
 }) }}
 
-{{ govukInput({
+{{ hmpoText(ctx, {
   id: "addressHouseNumber",
   name: "addressHouseNumber",
   label: { text: translate("fields.addressHouseNumber.label") },
-  classes: "govuk-input--width-5",
-  value: addressHouseNumber
+  classes: "govuk-input--width-5"
 }) }}
 
-{{ govukInput({
+{{ hmpoText(ctx, {
   id: "addressHouseName",
   name: "addressHouseName",
   label: { text: translate("fields.addressHouseName.label") },
-  classes: "govuk-input--width-20",
-  value: addressHouseName
+  classes: "govuk-input--width-20"
 }) }}
 
-{{ govukInput({
+{{ hmpoText(ctx,{
   id: "addressStreetName",
   name: "addressStreetName",
   label: { text: translate("fields.addressStreetName.label") },
-  classes: "govuk-input--width-20",
-  value: addressStreetName
+  classes: "govuk-input--width-20"
 }) }}
 
-{{ govukInput({
+{{ hmpoText(ctx, {
   id: "addressLocality",
   name: "addressLocality",
   label: { text: translate("fields.addressLocality.label") },
-  classes: "govuk-input--width-20",
-  value: addressLocality
+  classes: "govuk-input--width-20"
 }) }}

--- a/src/views/address/components/address-year-from-field.html
+++ b/src/views/address/components/address-year-from-field.html
@@ -1,11 +1,10 @@
-{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "hmpo-text/macro.njk" import hmpoText %}
 
 <h4>{{translate("fields.addressYearFrom.title")}}</h4>
 
-{{ govukInput({
+{{ hmpoText(ctx,{
   id: "addressYearFrom",
   name: "addressYearFrom",
   label: { text: translate("fields.addressYearFrom.label") },
-  classes: "govuk-input--width-4",
-  value: addressYearFrom
+  classes: "govuk-input--width-4"
 }) }}

--- a/test/utils/mocha-helpers.js
+++ b/test/utils/mocha-helpers.js
@@ -16,7 +16,11 @@ global.expect = expect;
 
 global.setupDefaultMocks = () => {
   const req = reqres.req({
-    form: { values: {} },
+    form: {
+      options: {
+        fields: {},
+      },
+    },
     axios: {
       get: sinon.fake(),
       post: sinon.fake(),


### PR DESCRIPTION
## Proposed changes

### What changed

Migration from GovUK components to hmpoComponents. This resulted in a extending getValues instead of locals in the wizard journey so that we could auto fill the components.

### Why did it change

GOVUK components don't directly inherit the validation design functionality that HMPO components have. As a result we're missing some design aspects of the GovUK design systems.
Rather than implement our own, we should go full in and use HMPO Components for full functionality. This required a change to use `getValues` instead of `locals` which makes more sense in hmpo-form-wizard journey. As locals shouldn't; be used to represent data that is about to be saved, in this situation.
