### PR TITLE
KBV-404-Building-name-clipped-confirm-page

### DIFF
--- a/src/app/address/controllers/address.js
+++ b/src/app/address/controllers/address.js
@@ -17,7 +17,8 @@ class AddressController extends BaseController {
       } else {
         // edit the chosen address
         address = req.sessionModel.get("chosenAddress");
-        values.addressPostcode = req.sessionModel.get("addressPostcode");
+        values.addressPostcode =
+          address?.postalCode || req.sessionModel.get("addressPostcode");
       }
 
       if (address) {
@@ -39,16 +40,30 @@ class AddressController extends BaseController {
   async saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       const isPreviousAddress = req.originalUrl.startsWith("/previous/address");
-
-      const address = this.buildAddress(req.body, isPreviousAddress);
-
-      address.postalCode = req.sessionModel.get("addressPostcode");
-
       const sessionsAddresses = req.sessionModel.get("addresses");
-
       const addresses = Array.isArray(sessionsAddresses)
         ? sessionsAddresses
         : [];
+
+      let chosenAddress = {};
+      if (req.originalUrl === "/previous/address/edit") {
+        chosenAddress = addresses[1];
+      } else if (req.originalUrl === "/address/edit") {
+        chosenAddress = addresses[0];
+      } else {
+        chosenAddress = req.sessionModel.get("chosenAddress") || {}; // empty object if no address chosen on address results
+      }
+
+      const address = this.buildAddress(
+        req.body,
+        isPreviousAddress,
+        chosenAddress
+      );
+
+      // only set postcode when we dont use OS response postcode
+      if (!address.postalCode) {
+        address.postalCode = req.sessionModel.get("addressPostcode");
+      }
 
       if (isPreviousAddress) {
         addresses[1] = address;
@@ -61,19 +76,22 @@ class AddressController extends BaseController {
     });
   }
 
-  buildAddress(reqBody, isPreviousAddress) {
-    const addressFlatNumber = reqBody.addressFlatNumber || null;
-    const addressHouseNumber = reqBody.addressHouseNumber || null;
-    const addressHouseName = reqBody.addressHouseName || null;
-    const addressStreetName = reqBody.addressStreetName;
-    const addressLocality = reqBody.addressLocality;
-
+  buildAddress(
+    {
+      addressFlatNumber,
+      addressHouseNumber,
+      addressHouseName,
+      addressStreetName,
+      addressLocality,
+      addressYearFrom,
+    } = undefined,
+    isPreviousAddress,
+    chosenAddress
+  ) {
     // only want year from for current address
-    let addressYearFrom = null;
+    let yearFrom = null;
     if (!isPreviousAddress) {
-      addressYearFrom = new Date(reqBody.addressYearFrom)
-        .toISOString()
-        .split("T")[0];
+      yearFrom = new Date(addressYearFrom).toISOString().split("T")[0];
     }
 
     const address = {
@@ -81,10 +99,39 @@ class AddressController extends BaseController {
       buildingName: addressHouseName,
       streetName: addressStreetName,
       addressLocality,
-      validFrom: addressYearFrom,
+      validFrom: yearFrom,
     };
 
-    return address;
+    const isChanged = this.checkForChanges(address, chosenAddress);
+
+    // any changed fields will be overwriten by 'address'
+    // Retains all special fields (sub building name, UPRN etc)
+    const updatedAddress = {
+      ...chosenAddress,
+      uprn: isChanged ? undefined : chosenAddress.uprn,
+    };
+
+    return { ...updatedAddress, ...address };
+  }
+
+  checkForChanges(reqBody, chosenAddress) {
+    const hasChanged = Object.keys(reqBody).findIndex((addressField) => {
+      const reqBodyValue = reqBody[addressField];
+      const chosenAddressValue = chosenAddress[addressField];
+      // handle if field is empty string in reqBody AND undefined in chosenAddress
+      if (
+        reqBodyValue === "" &&
+        (chosenAddressValue === undefined || chosenAddressValue === "")
+      ) {
+        return false;
+      }
+
+      if (reqBodyValue !== undefined && chosenAddressValue !== undefined) {
+        return reqBodyValue !== chosenAddressValue;
+      }
+    });
+
+    return hasChanged !== -1;
   }
 }
 module.exports = AddressController;

--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -1,5 +1,7 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 
+const { generateHTMLofAddress } = require("../presenters/addressPresenter");
+
 const {
   API: {
     PATHS: { SAVE_ADDRESS },
@@ -14,7 +16,8 @@ class AddressConfirmController extends BaseController {
       const sessionAddresses = req.sessionModel.get("addresses");
 
       const addresses = sessionAddresses.map((address) => {
-        return this.formatAddress(address);
+        const addressHtml = generateHTMLofAddress(address);
+        return { ...address, text: addressHtml };
       });
 
       const currentAddress = addresses.shift();
@@ -65,18 +68,6 @@ class AddressConfirmController extends BaseController {
     } catch (err) {
       callback(err);
     }
-  }
-
-  formatAddress(address) {
-    let buildingNameNumber;
-    if (address.buildingName && address.buildingNumber) {
-      buildingNameNumber = `${address.buildingNumber} ${address.buildingName}`;
-    } else {
-      buildingNameNumber = address.buildingName || address.buildingNumber;
-    }
-
-    const text = `${buildingNameNumber}<br>${address.streetName},<br>${address.addressLocality},<br>${address.postalCode}<br>`;
-    return { ...address, text };
   }
 
   async saveAddressess(axios, addresses, sessionId) {

--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -1,3 +1,7 @@
+const {
+  generateSearchResultString,
+} = require("../presenters/addressPresenter");
+
 const BaseController = require("hmpo-form-wizard").Controller;
 
 const {
@@ -36,7 +40,10 @@ class AddressSearchController extends BaseController {
     const addressResults = await axios.get(`${POSTCODE_LOOKUP}/${postcode}`, {
       headers,
     });
-    const addresses = addressResults.data.map(this.addLabel);
+    const addresses = addressResults.data.map((address) => {
+      const textView = generateSearchResultString(address);
+      return { ...address, text: textView, value: textView };
+    });
 
     const defaultMessage = {
       text: `${addresses.length} addresses found`,
@@ -44,57 +51,6 @@ class AddressSearchController extends BaseController {
     };
 
     return [defaultMessage, ...addresses];
-  }
-
-  // add a pretty print for drop down menu.
-  // need text + value to be the same to suit the framework.
-  addLabel(address) {
-    let buildingNames = [];
-    let streetNames = [];
-    let localityNames = [];
-
-    // handle building name
-    if (address.organisationName) {
-      buildingNames.push(address.organisationName);
-    }
-    if (address.departmentName) {
-      buildingNames.push(address.departmentName);
-    }
-    if (address.buildingName) {
-      buildingNames.push(address.buildingName);
-    }
-    if (address.subBuildingName) {
-      buildingNames.push(address.subBuildingName);
-    }
-    if (address.buildingNumber) {
-      buildingNames.push(address.buildingNumber);
-    }
-
-    // street names
-    if (address.dependentStreetName) {
-      streetNames.push(address.dependentStreetName);
-    }
-    if (address.streetName) {
-      streetNames.push(address.streetName);
-    }
-
-    // locality names
-    if (address.doubleDependentAddressLocality) {
-      localityNames.push(address.doubleDependentAddressLocality);
-    }
-    if (address.dependentAddressLocality) {
-      localityNames.push(address.dependentAddressLocality);
-    }
-    if (address.addressLocality) {
-      localityNames.push(address.addressLocality);
-    }
-
-    const fullBuildingName = buildingNames.join(" ");
-    const fullStreetName = streetNames.join(" ");
-    const fullLocality = localityNames.join(" ");
-    const text = `${fullBuildingName} ${fullStreetName}, ${fullLocality}, ${address.postalCode}`;
-
-    return { ...address, text, value: text };
   }
 }
 

--- a/src/app/address/presenters/addressPresenter.js
+++ b/src/app/address/presenters/addressPresenter.js
@@ -1,0 +1,67 @@
+module.exports = {
+  generateSearchResultString: function (address) {
+    const { buildingNames, streetNames, localityNames } =
+      extractAddressFields(address);
+    const fullBuildingName = buildingNames.join(" ");
+    const fullStreetName = streetNames.join(" ");
+    const fullLocality = localityNames.join(" ");
+    const text = `${fullBuildingName} ${fullStreetName}, ${fullLocality}, ${address.postalCode}`;
+
+    return text;
+  },
+  generateHTMLofAddress: function (address) {
+    const { buildingNames, streetNames, localityNames } =
+      extractAddressFields(address);
+
+    const fullBuildingName = buildingNames.join(" ");
+    const fullStreetName = streetNames.join(" ");
+    const fullLocality = localityNames.join(" ");
+
+    const text = `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+
+    return text;
+  },
+};
+
+function extractAddressFields(address) {
+  let buildingNames = [];
+  let streetNames = [];
+  let localityNames = [];
+
+  // handle building name
+  if (address.organisationName) {
+    buildingNames.push(address.organisationName);
+  }
+  if (address.departmentName) {
+    buildingNames.push(address.departmentName);
+  }
+  if (address.buildingName) {
+    buildingNames.push(address.buildingName);
+  }
+  if (address.subBuildingName) {
+    buildingNames.push(address.subBuildingName);
+  }
+  if (address.buildingNumber) {
+    buildingNames.push(address.buildingNumber);
+  }
+
+  // street names
+  if (address.dependentStreetName) {
+    streetNames.push(address.dependentStreetName);
+  }
+  if (address.streetName) {
+    streetNames.push(address.streetName);
+  }
+
+  // locality names
+  if (address.doubleDependentAddressLocality) {
+    localityNames.push(address.doubleDependentAddressLocality);
+  }
+  if (address.dependentAddressLocality) {
+    localityNames.push(address.dependentAddressLocality);
+  }
+  if (address.addressLocality) {
+    localityNames.push(address.addressLocality);
+  }
+  return { buildingNames, streetNames, localityNames };
+}

--- a/src/app/address/presenters/addressPresenter.test.js
+++ b/src/app/address/presenters/addressPresenter.test.js
@@ -1,0 +1,63 @@
+const { expect } = require("chai");
+const {
+  generateSearchResultString,
+  generateHTMLofAddress,
+} = require("./addressPresenter");
+
+describe("Address Presenter", () => {
+  describe("generateSearchResultString", () => {
+    const data = [
+      {
+        address: {
+          organisationName: "My company",
+          departmentName: "My deparment",
+          buildingName: "my building",
+          subBuildingName: "Room 5",
+          buildingNumber: "1",
+          dependentStreetName: "My outter street",
+          streetName: "my inner street",
+          doubleDependentAddressLocality: "My double dependant town",
+          dependentAddressLocality: "my dependant town",
+          addressLocality: "my town",
+          postalCode: "myCode",
+        },
+        text: "My company My deparment my building Room 5 1 My outter street my inner street, My double dependant town my dependant town my town, myCode",
+      },
+    ];
+
+    data.forEach((addressData, index) => {
+      it(`should match test address ${index} to its expected text output`, () => {
+        const output = generateSearchResultString(addressData.address);
+        expect(output).to.equal(addressData.text);
+      });
+    });
+  });
+
+  describe("generateHTMLofAddress", () => {
+    const data = [
+      {
+        address: {
+          organisationName: "My company",
+          departmentName: "My deparment",
+          buildingName: "my building",
+          subBuildingName: "Room 5",
+          buildingNumber: "1",
+          dependentStreetName: "My outter street",
+          streetName: "my inner street",
+          doubleDependentAddressLocality: "My double dependant town",
+          dependentAddressLocality: "my dependant town",
+          addressLocality: "my town",
+          postalCode: "myCode",
+        },
+        text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+      },
+    ];
+
+    data.forEach((addressData, index) => {
+      it(`should match test address ${index} to its expected text output`, () => {
+        const output = generateHTMLofAddress(addressData.address);
+        expect(output).to.equal(addressData.text);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Part 2 of additional address fields being missed.

### Why did it change

Address fields are being missed from view and then not saved in the VC. This is because we lose concept of the address fields when moving from results to address to confirm. This PR makes sure the address retains fields not show (this is a separate issue) and then displays them correct in the confirmation page.

If any additional edits are made the address, we delete the UPRN. This is to stop someone from modifying the address but retaining the UPRN and potentially showing incorrect data in the VC.

### Issue tracking

- [KBV-404](https://govukverify.atlassian.net/browse/KBV-404)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
