### PR TITLE
Kbv 436 add validation to results drop down

### DIFF
--- a/src/app/address/controllers/addressResults.js
+++ b/src/app/address/controllers/addressResults.js
@@ -11,7 +11,7 @@ class AddressResultsController extends BaseController {
   saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       try {
-        const selectedAddress = req.body["address-selection"];
+        const selectedAddress = req.body.addressResults;
         const allAddresses = req.sessionModel.get("searchResults");
 
         const chosenAddress = Object.assign(

--- a/src/app/address/controllers/addressResults.js
+++ b/src/app/address/controllers/addressResults.js
@@ -11,7 +11,7 @@ class AddressResultsController extends BaseController {
   saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       try {
-        const selectedAddress = req.body.addressResults;
+        const selectedAddress = req.form.values.addressResults;
         const allAddresses = req.sessionModel.get("searchResults");
 
         const chosenAddress = Object.assign(

--- a/src/app/address/controllers/addressResults.test.js
+++ b/src/app/address/controllers/addressResults.test.js
@@ -34,7 +34,7 @@ describe("Address result controller", () => {
   it("Should set the chosen address in the session", async () => {
     const expectedResponse = testData.formattedAddressed[1];
 
-    req.body.addressResult = expectedResponse.value;
+    req.form.values.addressResults = expectedResponse.value;
 
     req.sessionModel.set("searchResults", testData.formattedAddressed);
 
@@ -44,6 +44,7 @@ describe("Address result controller", () => {
     expect(req.session.test.chosenAddress.buildingNumber).to.equal(
       expectedResponse.buildingNumber
     );
+
     expect(req.session.test.chosenAddress.streetName).to.equal(
       expectedResponse.streetName
     );

--- a/src/app/address/controllers/addressResults.test.js
+++ b/src/app/address/controllers/addressResults.test.js
@@ -34,7 +34,7 @@ describe("Address result controller", () => {
   it("Should set the chosen address in the session", async () => {
     const expectedResponse = testData.formattedAddressed[1];
 
-    req.body["address-selection"] = expectedResponse.value;
+    req.body.addressResult = expectedResponse.value;
 
     req.sessionModel.set("searchResults", testData.formattedAddressed);
 

--- a/src/app/address/controllers/addressSearch.js
+++ b/src/app/address/controllers/addressSearch.js
@@ -40,6 +40,7 @@ class AddressSearchController extends BaseController {
 
     const defaultMessage = {
       text: `${addresses.length} addresses found`,
+      value: "",
     };
 
     return [defaultMessage, ...addresses];

--- a/src/app/address/controllers/addressSearch.test.js
+++ b/src/app/address/controllers/addressSearch.test.js
@@ -58,6 +58,7 @@ describe("Address Search controller", () => {
       );
       expect(req.session.test.searchResults[0]).to.deep.equal({
         text: `${testData.apiResponse.data.length} addresses found`,
+        value: "",
       });
       expect(req.session.test.addressPostcode).to.equal(testPostcode);
 

--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -141,4 +141,12 @@ module.exports = {
       },
     ],
   },
+  addressResults: {
+    type: "list",
+    validate: [
+      {
+        type: "required",
+      },
+    ],
+  },
 };

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -25,7 +25,7 @@ module.exports = {
   },
   "/results": {
     controller: results,
-    fields: ["address-results"],
+    fields: ["addressResults"],
     next: "address",
   },
   "/address": {
@@ -72,7 +72,7 @@ module.exports = {
   },
   "/previous/results": {
     controller: results,
-    fields: ["address-results"],
+    fields: ["addressResults"],
     next: "previous/address",
   },
   "/previous/address": {

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -38,8 +38,10 @@ addressYearFrom:
     default: Enter a valid date
     isPreviousDate: The date you started living at this address must be in the past
 
-address-results:
+addressResults:
   label: Select an address
+  validation:
+    required: Choose an address from the list
 
 address-confirm:
   current: Current address

--- a/src/views/address/components/address-results-field.html
+++ b/src/views/address/components/address-results-field.html
@@ -1,6 +1,6 @@
 
 {{ hmpoSelect(ctx, {
-  id: "address-selection",
-  label: translate("fields.address-results.label"),
+  id: "addressResults",
+  label: translate("fields.addressResults.label"),
   items: values.searchResults
 }) }}

--- a/test/utils/mocha-helpers.js
+++ b/test/utils/mocha-helpers.js
@@ -20,6 +20,7 @@ global.setupDefaultMocks = () => {
       options: {
         fields: {},
       },
+      values: {},
     },
     axios: {
       get: sinon.fake(),


### PR DESCRIPTION
## Proposed changes

### What changed

- Added validation to address results dropdown.
- Refactor variable name to camelCase 

### Why did it change

This is additional validation for the results page, to stop users from clicking the default message accidentally.

### Issue tracking

- [KBV-436](https://govukverify.atlassian.net/browse/KBV-436)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

![image](https://user-images.githubusercontent.com/8826525/170503700-2d97a9d1-805c-4840-a67c-9d15d60ec9e7.png)
