### PR TITLE
KBV-509-Confirmation-radio-button-always-pushed-user-to-previous-address-journey

### DIFF
--- a/src/app/address/controllers/addressConfirm.test.js
+++ b/src/app/address/controllers/addressConfirm.test.js
@@ -61,7 +61,7 @@ describe("Address confirmation controller", () => {
       const currentAddress = formattedAddresses.shift();
       const previousAddress = formattedAddresses.shift();
       const params = {
-        isMoreInfoRequirred: false, // not required as we already have a previous address
+        isMoreInfoRequired: false, // not required as we already have a previous address
         currentAddressRowValue: currentAddress,
         validFromRow: String(new Date().getFullYear()),
         previousAddressRowValue: previousAddress,
@@ -107,7 +107,7 @@ describe("Address confirmation controller", () => {
     });
 
     it("Should reset journey wide variables and enter previous journey when more information is required", async () => {
-      req.body.moreInfoRequired = true;
+      req.form.values.isAddressMoreThanThreeMonths = "lessThanThreeMonths";
       await addressConfirm.saveValues(req, res, next);
       expect(req.session.test.addressSearch).to.equal(null);
       expect(req.session.test.addPreviousAddresses).to.equal(true);

--- a/src/app/address/fields.js
+++ b/src/app/address/fields.js
@@ -133,13 +133,10 @@ module.exports = {
       },
     ],
   },
-  moreInfoRequired: {
-    type: "radio",
-    validate: [
-      {
-        type: "required",
-      },
-    ],
+  isAddressMoreThanThreeMonths: {
+    type: "radios",
+    items: ["moreThanThreeMonths", "lessThanThreeMonths"],
+    validate: [], // custom validator in addressConfirm.js
   },
   addressResults: {
     type: "list",

--- a/src/app/address/steps.js
+++ b/src/app/address/steps.js
@@ -46,7 +46,7 @@ module.exports = {
   "/confirm": {
     controller: confirm,
     prereqs: "/address/edit",
-    field: ["addPrevious", "moreInfoRequired"],
+    fields: ["addPrevious", "isAddressMoreThanThreeMonths"],
     next: [
       {
         field: "addPreviousAddresses",

--- a/src/app/address/validators/confirmationValidator.js
+++ b/src/app/address/validators/confirmationValidator.js
@@ -1,0 +1,8 @@
+module.exports = {
+  confirmationValidation: function (val, isPreviousJourney) {
+    if (isPreviousJourney) {
+      return true; // pass validation when in previous journey
+    }
+    return !!val;
+  },
+};

--- a/src/app/address/validators/confirmationValidtor.test.js
+++ b/src/app/address/validators/confirmationValidtor.test.js
@@ -1,0 +1,29 @@
+const { confirmationValidation } = require("./confirmationValidator");
+
+describe("Address confrimation validator", () => {
+  describe("confirmationValidation", () => {
+    it("should pass when previous address has been added", () => {
+      const isPreviousJourney = true;
+      expect(confirmationValidation("testInput", isPreviousJourney)).to.equal(
+        true
+      );
+    });
+
+    it("should pass when value is passed and not in previous address journey", () => {
+      const isPreviousJourney = false;
+      expect(confirmationValidation("testInput", isPreviousJourney)).to.equal(
+        true
+      );
+    });
+
+    it("should fail when empty string value is passed and not in previous address journey - empty string", () => {
+      const isPreviousJourney = false;
+      expect(confirmationValidation("", isPreviousJourney)).to.equal(false);
+    });
+
+    it("should fail when null value is passed and not in previous address journey", () => {
+      const isPreviousJourney = false;
+      expect(confirmationValidation(null, isPreviousJourney)).to.equal(false);
+    });
+  });
+});

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -49,12 +49,15 @@ address-confirm:
   previous: Previous address
   change: Change
 
-addressLivingDuration:
+isAddressMoreThanThreeMonths:
   label: Have you lived here for more than 3 months?
   hint: We'll need to ask you where you lived before if you've recently moved to this address.
   items:
-    moreInfoRequired:
-      moreInfoRequired:
-        text: "No"
-      moreInfoNotRequired:
-        text: "Yes"
+    moreThanThreeMonths:
+      label: "Yes"
+      value: "Yes"
+    lessThanThreeMonths:
+      label: "No"
+      value: "No"
+  validation:
+    confirmationValidation: Select yes if you've lived at this address for more than 3 months

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -1,9 +1,9 @@
 {% extends "./templates/address-base.html" %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "hmpo-html/macro.njk" import hmpoHtml %}
 {% from "hmpo-submit/macro.njk" import hmpoSubmit %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "hmpo-radios/macro.njk" import hmpoRadios %}
+
 
 
 {% set hmpoPageKey = "address-confirm" %}
@@ -115,32 +115,19 @@
 
   {% call hmpoForm(ctx) %}
 
-    {% if isMoreInfoRequirred %}
-      {{ govukRadios({
-        classes: "govuk-radios--inline",
-        id: "moreInfoRequired",
-        name: "moreInfoRequired",
-        value: moreInfoRequired,
-        fieldset: {
-          legend: {
-            text: translate("fields.addressLivingDuration.label"),
-            classes: "govuk-fieldset__legend--s"
-          }
+    {% if isMoreInfoRequired %}
+
+      {{ hmpoRadios(ctx, {
+        id: "isAddressMoreThanThreeMonths",
+        name: "isAddressMoreThanThreeMonths",
+        value: "isAddressMoreThanThreeMonths",
+        inline: true,
+        label: {
+          classes: ["govuk-fieldset__legend--s"]
         },
-        hint: {
-          text: translate("fields.addressLivingDuration.hint")
-        },
-        items: [
-          {
-            value: false,
-            text: translate("fields.addressLivingDuration.items.moreInfoRequired.moreInfoNotRequired.text")
-          },
-          {
-            value: true,
-            text: translate("fields.addressLivingDuration.items.moreInfoRequired.moreInfoRequired.text")
-          }
-        ]
+        fields: isAddressMoreThanThreeMonths.items
       }) }}
+
     {% endif %}
 
     {{ hmpoSubmit(ctx, {


### PR DESCRIPTION
## Proposed changes

### What changed

I refactored the radio button into hmpo radios, by doing this I was also able to add validation for the radio button.
Refactoring also fixed the bug in the ticket and reduced code. 

### Why did it change

Regardless of what the user choose, the wizard always took them to the previous address journey

### Issue tracking

- [KBV-509](https://govukverify.atlassian.net/browse/KBV-509)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
