### PR TITLE
Bugfix: validation on address modal require throws error when modal isnt shown

### DIFF
--- a/src/app/address/controllers/addressConfirm.js
+++ b/src/app/address/controllers/addressConfirm.js
@@ -47,9 +47,16 @@ class AddressConfirmController extends BaseController {
     const addresses = req.sessionModel.get("addresses");
     const hasPreviousAddresses = addresses.length === 2 ? true : false;
 
+    const currentAddress = addresses[0];
+
+    const yearFrom = new Date(currentAddress.validFrom).getFullYear();
+    const today = new Date();
+
+    const isMoreInfoRequired = this.isMoreInfoRequired(yearFrom, today);
+
     formFields.isAddressMoreThanThreeMonths?.validate.push({
       fn: confirmationValidation,
-      arguments: [hasPreviousAddresses],
+      arguments: [hasPreviousAddresses, isMoreInfoRequired],
     });
 
     super.validateFields(req, res, callback);

--- a/src/app/address/validators/confirmationValidator.js
+++ b/src/app/address/validators/confirmationValidator.js
@@ -1,8 +1,18 @@
 module.exports = {
-  confirmationValidation: function (val, isPreviousJourney) {
+  confirmationValidation: function (
+    val,
+    isPreviousJourney,
+    isMoreInfoRequired
+  ) {
     if (isPreviousJourney) {
       return true; // pass validation when in previous journey
     }
+
+    if (!isMoreInfoRequired) {
+      return true;
+    }
+
     return !!val;
+    // return true;
   },
 };

--- a/src/app/address/validators/confirmationValidtor.test.js
+++ b/src/app/address/validators/confirmationValidtor.test.js
@@ -2,28 +2,48 @@ const { confirmationValidation } = require("./confirmationValidator");
 
 describe("Address confrimation validator", () => {
   describe("confirmationValidation", () => {
-    it("should pass when previous address has been added", () => {
+    it("should pass when previous address is added", () => {
       const isPreviousJourney = true;
-      expect(confirmationValidation("testInput", isPreviousJourney)).to.equal(
-        true
-      );
+      expect(confirmationValidation("", isPreviousJourney)).to.equal(true);
     });
 
-    it("should pass when value is passed and not in previous address journey", () => {
+    it("should pass when a value is passed and not in previous address journey", () => {
       const isPreviousJourney = false;
       expect(confirmationValidation("testInput", isPreviousJourney)).to.equal(
         true
       );
     });
 
-    it("should fail when empty string value is passed and not in previous address journey - empty string", () => {
+    it("should fail when an empty string is passed, we're not in previous journey and additional addresses are needed - empty string", () => {
       const isPreviousJourney = false;
-      expect(confirmationValidation("", isPreviousJourney)).to.equal(false);
+      const isAdditonalFieldRequired = true;
+      expect(
+        confirmationValidation("", isPreviousJourney, isAdditonalFieldRequired)
+      ).to.equal(false);
     });
 
-    it("should fail when null value is passed and not in previous address journey", () => {
+    it("should fail when null is passed, we're not in previous and additional addresses are needed - null string", () => {
       const isPreviousJourney = false;
-      expect(confirmationValidation(null, isPreviousJourney)).to.equal(false);
+      const isAdditonalFieldRequired = true;
+      expect(
+        confirmationValidation(
+          null,
+          isPreviousJourney,
+          isAdditonalFieldRequired
+        )
+      ).to.equal(false);
+    });
+
+    it("should pass when a value is passed and addititonal info modal is needed", () => {
+      const isPreviousJourney = false;
+      const isAdditonalFieldRequired = true;
+      expect(
+        confirmationValidation(
+          "testValue",
+          isPreviousJourney,
+          isAdditonalFieldRequired
+        )
+      ).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

We're not checking if the modal for additional addresses has popped up when doing validation on it. To fix this, we use the same logic to check if the modal should appear and use that in the validation as well.

### Why did it change

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
