### PR TITLE
BAU-update-browser-tests-confirm-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ These should be able to be run using cucumber-js as below:
 ./test/brower $ cucumber-js --tags "@live"
 ```
 
+## Running browser tests in isolation
+
+You can run browser tests in isolation by decorating the scenario with a `@only` tag and then running `yarn run test:browser:ci:only`.
+
+eg:
+```
+  @only
+  Scenario: Address error
+  ...
+```
+
 ### Code Owners
 
 This repo has a `CODEOWNERS` file in the root and is configured to require PRs to reviewed by Code Owners.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "test:watch": "mocha --watch",
     "mocks": "yarn run wiremock --port 8010 --root-dir test/mocks",
     "test:browser": "wait-on tcp:8010 tcp:5010 && MOCK_API=true cucumber-js --config test/browser/cucumber.js",
-    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser"
+    "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
+    "test:browser:only": "wait-on tcp:8010 tcp:5010 && MOCK_API=true cucumber-js --config test/browser/cucumber.js --tags @only",
+    "test:browser:ci:only": "npm-run-all -p -r start:ci mocks test:browser:only"
   },
   "repository": {
     "type": "git",

--- a/src/views/address/confirm.html
+++ b/src/views/address/confirm.html
@@ -32,7 +32,10 @@
             items: [
               {
                 href: "/address/edit",
-                text: translate("fields.address-confirm.change")
+                text: translate("fields.address-confirm.change"),
+                attributes: {
+                  "data-id": "yearFromChange"
+                }
               }
             ]
           }
@@ -48,7 +51,10 @@
             items: [
               {
                 href: "/address/edit",
-                text: translate("fields.address-confirm.change")
+                text: translate("fields.address-confirm.change"),
+                attributes: {
+                  "data-id": "yearFromChange"
+                }
               }
             ]
           }
@@ -64,7 +70,10 @@
             items: [
               {
                 href: "/previous/address/edit",
-                text: translate("fields.address-confirm.change")
+                text: translate("fields.address-confirm.change"),
+                attributes: {
+                  "data-id": "previousAddressChange"
+                }
               }
             ]
           }
@@ -87,7 +96,10 @@
             items: [
               {
                 href: "/address/edit",
-                text: translate("fields.address-confirm.change")
+                text: translate("fields.address-confirm.change"),
+                attributes: {
+                  "data-id": "currentAddressChange"
+                }
               }
             ]
           }
@@ -103,7 +115,10 @@
             items: [
               {
                 href: "/address/edit",
-                text: translate("fields.address-confirm.change")
+                text: translate("fields.address-confirm.change"),
+                attributes: {
+                  "data-id": "yearFromChange"
+                }
               }
             ]
           }

--- a/test/browser/features/address-confirm.feature
+++ b/test/browser/features/address-confirm.feature
@@ -1,0 +1,51 @@
+@mock-api:address-success @success
+Feature: Happy Path - confirming address details
+  Confirming address details
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+    Then they should see the results page
+    And they have selected an address
+    Then they should see the address page
+
+    Scenario: Adding an year date that should show the previous address modal
+      Given they are on the address page
+      When they add their residency date "current"
+      And they continue to confirm address
+      Then they should see the confirm page
+      And they should see the previous address modal
+
+    Scenario: Adding an year date that shouldnt show the previous address modal
+      Given they are on the address page
+      When they add their residency date "2000"
+      And they continue to confirm address
+      Then they should see the confirm page
+      And they should not see the previous address modal
+
+    Scenario: Changing an address
+      Given they are on the address page
+      When they add their residency date "current"
+      And they continue to confirm address
+      Then they should see the confirm page
+      When they click change current address
+      Then they should see the address page
+      When they add their street "Park street"
+      And they continue to confirm address
+      Then they should see the confirm page
+      And they should see the address value "Park street"
+
+    Scenario: Changing year from value
+      Given they are on the address page
+      When they add their residency date "current"
+      And they continue to confirm address
+      Then they should see the confirm page
+      When they click change year from
+      Then they should see the address page
+      When they add their residency date "2010"
+      And they continue to confirm address
+      Then they should see the confirm page
+      And they should see the year value "2010"
+
+

--- a/test/browser/features/address-confirm.feature
+++ b/test/browser/features/address-confirm.feature
@@ -12,7 +12,7 @@ Feature: Happy Path - confirming address details
 
     Scenario: Adding an year date that should show the previous address modal
       Given they are on the address page
-      When they add their residency date "current"
+      When they add their residency date "2022"
       And they continue to confirm address
       Then they should see the confirm page
       And they should see the previous address modal
@@ -22,7 +22,15 @@ Feature: Happy Path - confirming address details
       When they add their residency date "2000"
       And they continue to confirm address
       Then they should see the confirm page
-      And they should not see the previous address modal
+
+    Scenario: Adding an year date that should show the previous address modal
+      Given they are on the address page
+      When they add their residency date "2022"
+      And they continue to confirm address
+      Then they should see the confirm page
+      And they should see the previous address modal
+      When they confirm their details
+      Then they should see an error message "more than 3 months"
 
     Scenario: Changing an address
       Given they are on the address page

--- a/test/browser/pages/address.js
+++ b/test/browser/pages/address.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/address";
+    this.paths = ["/address", "/address/edit"];
   }
 
   async continue() {
@@ -22,7 +22,7 @@ module.exports = class PlaywrightDevPage {
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
 
-    return pathname === this.path;
+    return this.paths.findIndex((val) => val === pathname) !== -1;
   }
   async addHouseNumber(value = "1A") {
     await this.page.fill("#addressHouseNumber", value);

--- a/test/browser/pages/confirm.js
+++ b/test/browser/pages/confirm.js
@@ -7,8 +7,16 @@ module.exports = class PlaywrightDevPage {
     this.path = "/confirm";
   }
 
-  async changeAddress() {
-    await this.page.click("#change-address");
+  async changeCurrentAddress() {
+    await this.page.click('[data-id="currentAddressChange"]');
+  }
+
+  async changeYearFrom() {
+    await this.page.click('[data-id="yearFromChange"]');
+  }
+
+  async changePreviousAddress() {
+    await this.page.click('[data-id="previousAddressChange"]');
   }
 
   async confirmDetails() {
@@ -31,5 +39,32 @@ module.exports = class PlaywrightDevPage {
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
     return pathname === this.path;
+  }
+
+  async returnCurrentAddress() {
+    const currAddressResp = await this.page
+      .locator(
+        "#main-content > div > div > dl > div:nth-child(1) > dd.govuk-summary-list__value"
+      )
+      .allTextContents();
+    return currAddressResp[0];
+  }
+
+  async returnYearFromValue() {
+    const yearResp = await this.page
+      .locator(
+        "#main-content > div > div > dl > div:nth-child(2) > dd.govuk-summary-list__value"
+      )
+      .allTextContents();
+    return yearResp[0];
+  }
+
+  async returnPreviousAddressValue() {
+    const yearResp = await this.page
+      .locator(
+        "#main-content > div > div > dl > div:nth-child(3) > dd.govuk-summary-list__value"
+      )
+      .allTextContents();
+    return yearResp[0];
   }
 };

--- a/test/browser/pages/confirm.js
+++ b/test/browser/pages/confirm.js
@@ -23,17 +23,20 @@ module.exports = class PlaywrightDevPage {
     await this.page.click('[data-id="next"]');
   }
 
-  async isRadioSelectorVisible() {
-    return await this.page.isVisible('[data-id="getPreviousAddressRadios"]');
-  }
   async selectNoRadioButton() {
     await this.page
-      .locator("id=isAddressMoreThanThreeMonths-lessThanThreeMonths")
+      .locator("#isAddressMoreThanThreeMonths-lessThanThreeMonths")
       .click();
   }
 
+  async returnRadioLegend() {
+    return this.page.textContent(
+      "#isAddressMoreThanThreeMonths-fieldset > legend"
+    );
+  }
+
   async selectYesRadioButton() {
-    await this.page.locator("id=isAddressMoreThanThreeMonths").click();
+    await this.page.locator("#isAddressMoreThanThreeMonths").click();
   }
 
   isCurrentPage() {
@@ -41,30 +44,25 @@ module.exports = class PlaywrightDevPage {
     return pathname === this.path;
   }
 
-  async returnCurrentAddress() {
-    const currAddressResp = await this.page
-      .locator(
-        "#main-content > div > div > dl > div:nth-child(1) > dd.govuk-summary-list__value"
-      )
-      .allTextContents();
-    return currAddressResp[0];
+  returnCurrentAddress() {
+    return this.page.textContent(
+      "#main-content > div > div > dl > div:nth-child(1) > dd.govuk-summary-list__value"
+    );
   }
 
-  async returnYearFromValue() {
-    const yearResp = await this.page
-      .locator(
-        "#main-content > div > div > dl > div:nth-child(2) > dd.govuk-summary-list__value"
-      )
-      .allTextContents();
-    return yearResp[0];
+  returnYearFromValue() {
+    return this.page.textContent(
+      "#main-content > div > div > dl > div:nth-child(2) > dd.govuk-summary-list__value"
+    );
   }
 
-  async returnPreviousAddressValue() {
-    const yearResp = await this.page
-      .locator(
-        "#main-content > div > div > dl > div:nth-child(3) > dd.govuk-summary-list__value"
-      )
-      .allTextContents();
-    return yearResp[0];
+  returnPreviousAddressValue() {
+    return this.page.textContent(
+      "#main-content > div > div > dl > div:nth-child(3) > dd.govuk-summary-list__value"
+    );
+  }
+
+  getErrorSummary() {
+    return this.page.textContent(".govuk-error-summary");
   }
 };

--- a/test/browser/step_definitions/confirm.js
+++ b/test/browser/step_definitions/confirm.js
@@ -1,4 +1,4 @@
-const { Then } = require("@cucumber/cucumber");
+const { Then, When } = require("@cucumber/cucumber");
 const { ConfirmPage } = require("../pages");
 const { expect } = require("chai");
 
@@ -51,4 +51,36 @@ Then(
 Then("they should see the confirm page", function () {
   const confirmPage = new ConfirmPage(this.page);
   expect(confirmPage.isCurrentPage()).to.be.true;
+});
+
+Then("they should see the previous address modal", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  expect(await confirmPage.isRadioSelectorVisible()).to.be.true;
+});
+
+Then("they should not see the previous address modal", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  expect(await confirmPage.isRadioSelectorVisible()).to.be.false;
+});
+
+Then("they should see the address value {string}", async function (value) {
+  const confirmPage = new ConfirmPage(this.page);
+  const text = await confirmPage.returnCurrentAddress();
+  expect(text).to.contain(value);
+});
+
+Then("they should see the year value {string}", async function (value) {
+  const confirmPage = new ConfirmPage(this.page);
+  const text = await confirmPage.returnYearFromValue();
+  expect(text).to.contain(value);
+});
+
+When("they click change current address", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  await confirmPage.changeCurrentAddress();
+});
+
+When("they click change year from", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  await confirmPage.changeYearFrom();
 });

--- a/test/browser/step_definitions/confirm.js
+++ b/test/browser/step_definitions/confirm.js
@@ -24,18 +24,6 @@ Then("they should be able to confirm their details", async function () {
   await confirmPage.confirmDetails();
 });
 
-Then("they should see the additional details selector", async function () {
-  const confirmPage = new ConfirmPage(this.page);
-  const isVisible = await confirmPage.isRadioSelectorVisible();
-  expect(isVisible).to.equal(true);
-});
-
-Then("they should not see the additional details selector", async function () {
-  const confirmPage = new ConfirmPage(this.page);
-  const isVisible = await confirmPage.isRadioSelectorVisible();
-  expect(isVisible).to.equal(false);
-});
-
 Then(
   "they can select they have lived their for {string}",
   async function (value) {
@@ -53,26 +41,28 @@ Then("they should see the confirm page", function () {
   expect(confirmPage.isCurrentPage()).to.be.true;
 });
 
-Then("they should see the previous address modal", async function () {
-  const confirmPage = new ConfirmPage(this.page);
-  expect(await confirmPage.isRadioSelectorVisible()).to.be.true;
-});
-
-Then("they should not see the previous address modal", async function () {
-  const confirmPage = new ConfirmPage(this.page);
-  expect(await confirmPage.isRadioSelectorVisible()).to.be.false;
-});
-
 Then("they should see the address value {string}", async function (value) {
   const confirmPage = new ConfirmPage(this.page);
   const text = await confirmPage.returnCurrentAddress();
-  expect(text).to.contain(value);
+  expect(text).to.include(value);
 });
 
 Then("they should see the year value {string}", async function (value) {
   const confirmPage = new ConfirmPage(this.page);
   const text = await confirmPage.returnYearFromValue();
-  expect(text).to.contain(value);
+  expect(text).to.include(value);
+});
+
+Then("they should see the previous address modal", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  const radioLegendTitle = await confirmPage.returnRadioLegend();
+  expect(radioLegendTitle).to.include("more than 3 months");
+});
+
+Then("they should see an error message {string}", async function (value) {
+  const confirmPage = new ConfirmPage(this.page);
+  const text = await confirmPage.getErrorSummary();
+  expect(text).to.include(value);
 });
 
 When("they click change current address", async function () {
@@ -83,4 +73,9 @@ When("they click change current address", async function () {
 When("they click change year from", async function () {
   const confirmPage = new ConfirmPage(this.page);
   await confirmPage.changeYearFrom();
+});
+
+When("they confirm their details", async function () {
+  const confirmPage = new ConfirmPage(this.page);
+  await confirmPage.confirmDetails();
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Adding confirmation page browser tests for behaviour of going back and changing address details, confirming those changes.

Does not test going to the next step and exchanging access token etc.

### Why did it change

Tidy up of the browser tests + adding new ones.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks
