### PR TITLE
KBV-580-Add-error-summary-component-to-results-page

### DIFF
--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -5,7 +5,7 @@
 {% set hmpoPageKey = "address-results" %}
 {% set hmpoPageContent = "address-results" %}
 
-{% block content %}
+{% block mainContent %}
 
   <h1 id="header">{{translate("pages.address-results.title")}}</h1>
 

--- a/src/views/previous/results.html
+++ b/src/views/previous/results.html
@@ -5,7 +5,7 @@
 {% set hmpoPageKey = "address-previous" %}
 {% set hmpoPageContent = "address-previous" %}
 
-{% block content %}
+{% block mainContent %}
 
   <h1 id="header">{{translate("pages.address-previous.title")}}</h1>
 

--- a/test/browser/features/address-results-previous.feature
+++ b/test/browser/features/address-results-previous.feature
@@ -1,0 +1,20 @@
+@mock-api:address-success @success
+Feature: Happy Path - confirming preselected address details and date invalidation
+  Confirming address details
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+    Then they have selected an address ""
+    When they add their residency date "2022"
+    And they continue to confirm address
+    And they select the less than three months radio button
+    And they confirm their details
+    And they searched for their postcode "E1 8QS"
+    Then they should see the results page
+
+    Scenario: Showing validation messages on the showing an address
+      Given they have selected an address "default"
+      Then they should see the results page
+      And they should see an error message on the results page "Choose an address"

--- a/test/browser/features/address-results.feature
+++ b/test/browser/features/address-results.feature
@@ -1,0 +1,14 @@
+@mock-api:address-success @success
+Feature: Happy Path - confirming preselected address details and date invalidation
+  Confirming address details
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+    Then they should see the results page
+
+    Scenario: Showing validation messages on the showing an address
+      Given they have selected an address "default"
+      Then they should see the results page
+      And they should see an error message on the results page "Choose an address"

--- a/test/browser/pages/result.js
+++ b/test/browser/pages/result.js
@@ -23,6 +23,10 @@ module.exports = class PlaywrightDevPage {
     return this.page.textContent('[data-id="changePostcodeValue"]');
   }
 
+  getErrorSummary() {
+    return this.page.textContent(".govuk-error-summary");
+  }
+
   async selectCantFindMyAddress() {
     await this.page.click('[data-id="cantFindAddress"]');
   }

--- a/test/browser/step_definitions/results.js
+++ b/test/browser/step_definitions/results.js
@@ -23,6 +23,8 @@ When("they have selected an address {string}", async function (value) {
   const resultPage = new ResultsPage(this.page);
   if (value === "") {
     await resultPage.selectAddress();
+  } else if (value === "default") {
+    await resultPage.selectAddress("");
   } else {
     await resultPage.selectAddress(value);
   }
@@ -44,3 +46,12 @@ When(/they select change postcode$/, async function () {
   const resultsPage = new ResultsPage(this.page);
   await resultsPage.selectChangePostcode();
 });
+
+Then(
+  "they should see an error message on the results page {string}",
+  async function (value) {
+    const resultsPage = new ResultsPage(this.page);
+    const text = await resultsPage.getErrorSummary();
+    expect(text).to.include(value);
+  }
+);


### PR DESCRIPTION
## Proposed changes

### What changed

Change the template to overwrite the mainContent block instead of the whole contentBlock. This results in the error summary being shown.

Also added additional browser tests.

### Why did it change

This was one of the flags the accessibility audit.

![image](https://user-images.githubusercontent.com/8826525/174630834-64205e66-53c8-4521-9f37-b334bc339199.png)


### Issue tracking

- [KBV-580](https://govukverify.atlassian.net/browse/KBV-580)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed