### PR TITLE
KBV-586 validation on same address is not showing

### DIFF
--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -13,14 +13,7 @@ class AddressResultsController extends BaseController {
   }
 
   validateFields(req, res, callback) {
-    const currentWizard = req?.sessionModel?.options?.key;
-
-    let checkAddress;
-    if (currentWizard.endsWith("previous")) {
-      checkAddress = req.session["hmpo-wizard-address"]?.address;
-    } else {
-      checkAddress = req.session["hmpo-wizard-previous"]?.address;
-    }
+    const checkAddress = req.journeyModel.get("currentAddress");
     // only need to validate the address when there is another address already.
     if (checkAddress) {
       const formFields = req.form.options.fields;

--- a/test/browser/features/address-results-previous.feature
+++ b/test/browser/features/address-results-previous.feature
@@ -18,3 +18,8 @@ Feature: Happy Path - confirming preselected address details and date invalidati
       Given they have selected an address "default"
       Then they should see the results page
       And they should see an error message on the results page "Choose an address"
+
+    Scenario: Showing validation message when same address is chosen
+      Given they have selected an address ""
+      Then they should see the results page
+      And they should see an error message on the results page "previous address cannot be the same"

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -53,13 +53,15 @@
             "buildingNumber": "1",
             "addressLocality": "LONDON",
             "postalCode": "E1 8QS",
-            "streetName": "WHITECHAPEL HIGH STREET"
+            "streetName": "WHITECHAPEL HIGH STREET",
+            "uprn": "123"
           },
           {
             "buildingNumber": "10",
             "addressLocality": "LONDON",
             "postalCode": "E1 8QS",
-            "streetName": "WHITECHAPEL HIGH STREET"
+            "streetName": "WHITECHAPEL HIGH STREET",
+            "uprn": "124"
           }
         ]
       }


### PR DESCRIPTION
## Proposed changes

### What changed

A validation on same address appearing twice was broken after I merged a refactor of the wizards.

### Why did it change

This fixes a bug inside the validation of same address.

### Issue tracking

- [KBV-586](https://govukverify.atlassian.net/browse/KBV-586)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Added browser tests to cover this sceanrio
