### PR TITLE
Kbv 615/use common headers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const DynamoDBStore = require("connect-dynamodb")(session);
 
 const commonExpress = require("di-ipv-cri-common-express");
 
+const setHeaders = commonExpress.lib.headers;
 const setScenarioHeaders = commonExpress.lib.scenarioHeaders;
 const setAxiosDefaults = commonExpress.lib.axios;
 
@@ -64,6 +65,9 @@ const { app, router } = setup({
     ),
     "views",
   ],
+  middlewareSetupFn: (app) => {
+    app.use(setHeaders);
+  },
   dev: true,
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes


### What changed

Added middleware setup to rewrite the incoming request header value `x-forwarded-proto` to be https
Updated HMPO-App to 2.3.0 to have the ability to inject custom middleware

### Why did it change

The existing infrastructure configuration is causing the Load Balancer to forward the incorrect header `value x-fowarded-proto`.  Infrastructure cannot overwrite the value due to where the TLS termination ends and requires the app to explicitly trust that the original request is secure. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- https://github.com/alphagov/di-ipv-cri-uk-passport-front/pull/168
- [KBV-615](https://govukverify.atlassian.net/browse/KBV-615)
- [PYIC-1376](https://govukverify.atlassian.net/browse/PYIC-1376)

Requires merging and releasing of:

- [ ] https://github.com/alphagov/di-ipv-cri-common-express/pull/65

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
