### PR TITLE
KBV-683-add-session-ttl

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ const {
   PORT,
   SESSION_SECRET,
   SESSION_TABLE_NAME,
+  SESSION_TTL,
 } = require("./lib/config");
 
 const { setup } = require("hmpo-app");
@@ -55,6 +56,7 @@ const { app, router } = setup({
   port: PORT,
   logs: loggerConfig,
   session: sessionConfig,
+  maxAge: SESSION_TTL,
   redis: SESSION_TABLE_NAME ? false : commonExpress.lib.redis(),
   helmet: helmetConfig,
   urls: {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -23,6 +23,7 @@ module.exports = {
   PORT: process.env.PORT || 5010,
   SESSION_SECRET: process.env.SESSION_SECRET,
   SESSION_TABLE_NAME: process.env.SESSION_TABLE_NAME,
+  SESSION_TTL: process.env.SESSION_TTL || 7200000, // two hours in ms
   REDIS: {
     SESSION_URL: process.env.REDIS_SESSION_URL,
     PORT: process.env.REDIS_PORT || 6379,


### PR DESCRIPTION
## Proposed changes

### What changed

**testing** This is hard to test locally as we don't actually connect to dynamo db. We could spin up a local dynamo db table. However, I think just merging this small change and testing in build/stage could suffice. 

Added a Session TTL variable and allowed it to be overwritten by a process environment variable. Set the default to 720000 which is two hours in ms.  If we can confirm this works, then we should think about setting it in the common express somehow.

### Why did it change

The session is currently defaulting to 1 day, which is set in the library connect-dynamodb.

It appears that that's the default because no maxAge is supplied. From the express documentation, we just need to add maxAge properties to the options which are passed into express in the hmpo-app.

See - http://expressjs.com/en/api.html#express.static:~:text=true-,maxAge,-Set%20the%20max

(which doesn't make sense in my head as I would expect to pass maxAge where we define the session config. But hey, express is express.



### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [x] Added to deployment repository
- [x] Added to local startup repository

