### PR TITLE
OJ-878-set-instances-to-2

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -449,8 +449,8 @@ Resources:
     Condition: IsProduction
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 3
-      MinCapacity: 1
+      MaxCapacity: 4
+      MinCapacity: 2
       ResourceId: !Join
         - '/'
         - - "service"


### PR DESCRIPTION
## Proposed changes

### What changed

To get the frontend to 2 instances, I suspect we need to set this value to 2 to allow for a second instance. To keep the scaling size the same, I've increased the maximum as well.

### Why did it change

To set a min of two instances for the FE

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-878](https://govukverify.atlassian.net/browse/OJ-878)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
