### PR TITLE
Bugfix-stop-empty-address-being-saved

### DIFF
--- a/src/app/address/controllers/summary/confirm.js
+++ b/src/app/address/controllers/summary/confirm.js
@@ -79,6 +79,10 @@ class AddressConfirmController extends BaseController {
         const currentAddress = req.journeyModel.get("currentAddress");
         const previousAddress = req.journeyModel.get("previousAddress");
 
+        if (!currentAddress && !previousAddress) {
+          return callback(new Error("No address found"));
+        }
+
         const addresses = [currentAddress];
 
         if (previousAddress) {

--- a/src/app/address/controllers/summary/confirm.test.js
+++ b/src/app/address/controllers/summary/confirm.test.js
@@ -103,6 +103,20 @@ describe("Address confirmation controller", () => {
       await addressConfirm.saveValues(req, res, next);
       expect(req.session.test.addPreviousAddresses).to.equal(true);
     });
+
+    it("should return an error when no addresses are found", async () => {
+      req.journeyModel.set("currentAddress", null);
+      req.journeyModel.set("previousAddress", null);
+
+      await addressConfirm.saveValues(req, res, next);
+
+      const errMessage = "No address found";
+      const callbackError = next.firstArg;
+      expect(next).to.have.been.calledOnce;
+      expect(callbackError).to.be.instanceOf(Error);
+      expect(callbackError.message).to.equal(errMessage);
+      expect(next).to.have.been.calledWith();
+    });
   });
 
   describe("isMoreInfoRequired", () => {


### PR DESCRIPTION
## Proposed changes

### What changed

Bugfix: stop addresses being saved when no address found

### Why did it change

There is a usecase is causing the address frontend to send an empty array to be saved. This causes our backend to throw an error.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
