### PR TITLE
refactor: Send session_id & session-id for BE refactoring

### DIFF
--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -36,7 +36,9 @@ class AddressSearchController extends BaseController {
   }
 
   async search(axios, postcode, sessionId) {
-    const headers = sessionId ? { session_id: sessionId } : undefined; // set the header to null should fail the req but pass the browser tests for now.
+    const headers = sessionId
+      ? { session_id: sessionId, "session-id": sessionId }
+      : undefined; // set the header to null should fail the req but pass the browser tests for now.
 
     const addressResults = await axios.get(`${POSTCODE_LOOKUP}/${postcode}`, {
       headers,

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -53,6 +53,7 @@ describe("Address Search controller", () => {
         {
           headers: {
             session_id: sessionId,
+            "session-id": sessionId,
           },
         }
       );
@@ -91,6 +92,7 @@ describe("Address Search controller", () => {
         {
           headers: {
             session_id: sessionId,
+            "session-id": sessionId,
           },
         }
       );

--- a/src/app/address/controllers/summary/confirm.js
+++ b/src/app/address/controllers/summary/confirm.js
@@ -105,7 +105,9 @@ class AddressConfirmController extends BaseController {
 
   async saveAddressess(axios, addresses, sessionId) {
     // set the headers to undefined will a fail a production level request but pass the browser tests for now.
-    const headers = sessionId ? { session_id: sessionId } : undefined;
+    const headers = sessionId
+      ? { session_id: sessionId, "session-id": sessionId }
+      : undefined;
     const resp = await axios.put(`${SAVE_ADDRESS}`, addresses, {
       headers,
     });

--- a/src/app/address/controllers/summary/confirm.test.js
+++ b/src/app/address/controllers/summary/confirm.test.js
@@ -92,6 +92,7 @@ describe("Address confirmation controller", () => {
       expect(req.axios.put).to.have.been.calledWith(SAVE_ADDRESS, addresses, {
         headers: {
           session_id: sessionId,
+          "session-id": sessionId,
         },
       });
 

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -43,6 +43,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -77,6 +83,12 @@
           "x-scenario-id": {
             "equalTo": "address-success",
             "absent": false
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -95,6 +107,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -132,6 +150,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-success"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -147,11 +171,14 @@
         "method": "GET",
         "urlPath": "/authorization",
         "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-success"
+          },
           "session-id": {
             "equalTo": "ABADCAFE"
           },
-          "x-scenario-id": {
-            "equalTo": "address-success"
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },

--- a/test/mocks/mappings/authorization-error.json
+++ b/test/mocks/mappings/authorization-error.json
@@ -43,6 +43,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -77,6 +83,12 @@
           "x-scenario-id": {
             "equalTo": "address-authorization-error",
             "absent": false
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -95,6 +107,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -132,6 +150,12 @@
         "headers": {
           "x-scenario-id": {
             "equalTo": "address-authorization-error"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
@@ -147,11 +171,14 @@
         "method": "GET",
         "urlPath": "/authorization",
         "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-authorization-error"
+          },
           "session-id": {
             "equalTo": "ABADCAFE"
           },
-          "x-scenario-id": {
-            "equalTo": "address-authorization-error"
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

There is currently an inconsistency with the common API endpoints - some of them use `session-id` and some of them use `session_id`.

In order to non-breaking refactoring on the API - all the API requests will temporarily provide both parameters. Once the refactoring is complete, the unused parameter can be removed.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-962](https://govukverify.atlassian.net/browse/OJ-962)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
