### PR TITLE
OJ-985 update logging subscription filters

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,7 +253,7 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-AddressFront-ECS
       RetentionInDays: 14
 
-  ECSAccessLogsGroupSubscriptionFilterOld:
+  ECSAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
@@ -261,7 +261,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref ECSAccessLogsGroup
 
-  ECSAccessLogsGroupSubscriptionFilter:
+  ECSAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
@@ -441,7 +441,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-AddressFront-API-GW-AccessLogs
 
-  APIGWAccessLogsGroupSubscriptionFilterOld:
+  APIGWAccessLogsGroupSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
@@ -449,7 +449,7 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 
-  APIGWAccessLogsGroupSubscriptionFilter:
+  APIGWAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,11 +253,19 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-AddressFront-ECS
       RetentionInDays: 14
 
-  ECSAccessLogsGroupSubscriptionFilter:
+  ECSAccessLogsGroupSubscriptionFilterOld:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref ECSAccessLogsGroup
+
+  ECSAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref ECSAccessLogsGroup
 
@@ -433,11 +441,19 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-AddressFront-API-GW-AccessLogs
 
-  APIGWAccessLogsGroupSubscriptionFilter:
+  APIGWAccessLogsGroupSubscriptionFilterOld:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
     Properties:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
+      FilterPattern: ""
+      LogGroupName: !Ref APIGWAccessLogsGroup
+
+  APIGWAccessLogsGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add both old non python and new python subscription filters for splunk

### Why did it change

Requirement to use the new python subscription filters but to keep the old filters to ensure no logs get lost

### Issue tracking

- [OJ-985](https://govukverify.atlassian.net/browse/OJ-985)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks