### PR TITLE
Oj 913/i18next presenter spike

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "hmpo-form-wizard": "12.0.6",
     "hmpo-i18n": "5.0.2",
     "hmpo-logger": "6.1.1",
+    "i18next": "^21.9.1",
+    "i18next-http-middleware": "^3.2.1",
+    "i18next-sync-fs-backend": "^1.1.1",
     "jsonwebtoken": "8.5.1",
     "nunjucks": "3.2.3",
     "wiremock": "2.33.2"

--- a/src/app.js
+++ b/src/app.js
@@ -81,6 +81,33 @@ const { app, router } = setup({
   dev: true,
 });
 
+var i18nextConfigurationOptions = {
+  debug: false,
+  initImmediate: true,
+  supportedLngs: ["en", "cy"],
+  fallbackLng: ["en"],
+  preload: ["en", "cy"],
+  ns: ["default", "fields", "pages"],
+  defaultNS: "default",
+  backend: {
+    loadPath: "./src/locales/{{lng}}/{{ns}}.yml",
+  },
+  saveMissingTo: "current",
+};
+
+const configureI18next = (config) => {
+  const i18next = require("i18next");
+  const Backend = require("i18next-sync-fs-backend");
+  const i18nextMiddleware = require("i18next-http-middleware");
+
+  i18next.use(Backend).use(i18nextMiddleware.LanguageDetector).init(config);
+
+  return i18nextMiddleware.handle(i18next, {
+    ignoreRoutes: ["/public"], // or function(req, res, options, i18next) { /* return true to ignore */ }
+  });
+};
+router.use(configureI18next(i18nextConfigurationOptions));
+
 app.get("nunjucks").addGlobal("getContext", function () {
   return {
     keys: Object.keys(this.ctx),

--- a/src/app.js
+++ b/src/app.js
@@ -81,44 +81,9 @@ const { app, router } = setup({
   dev: true,
 });
 
-var i18nextConfigurationOptions = {
-  debug: true,
-  initImmediate: false,
-  supportedLngs: ["en", "cy"],
-  // fallbackLng: ["en"],
-  preload: ["en", "cy"],
-  ns: ["default", "fields", "pages"],
-  nsSeparator: ":",
-  returnEmptyString: true,
-  defaultNS: "default",
-  fallbackNS: ["fields", "pages"],
-  backend: {
-    loadPath: "./src/locales/{{lng}}/{{ns}}.yml",
-  },
-  saveMissingTo: "current",
-  detection: {
-    order: ["querystring", "cookie"],
-    caches: ["cookie"],
-    cookieMinutes: 160,
-    lookupQuerystring: "lng",
-    lookupCookie: "lng",
-  },
-};
+const locali18n = require("./lib/i18n");
 
-const configureI18next = (config) => {
-  console.log(">>>>>>> configureI18next");
-
-  const i18next = require("i18next");
-  const Backend = require("i18next-sync-fs-backend");
-  const i18nextMiddleware = require("i18next-http-middleware");
-
-  i18next.use(Backend).use(i18nextMiddleware.LanguageDetector).init(config);
-
-  return i18nextMiddleware.handle(i18next, {
-    ignoreRoutes: ["/public"], // or function(req, res, options, i18next) { /* return true to ignore */ }
-  });
-};
-router.use(configureI18next(i18nextConfigurationOptions));
+locali18n.configure({ app: router });
 
 app.get("nunjucks").addGlobal("getContext", function () {
   return {

--- a/src/app.js
+++ b/src/app.js
@@ -83,13 +83,13 @@ const { app, router } = setup({
 
 var i18nextConfigurationOptions = {
   debug: true,
-  initImmediate: true,
+  initImmediate: false,
   supportedLngs: ["en", "cy"],
   // fallbackLng: ["en"],
   preload: ["en", "cy"],
   ns: ["default", "fields", "pages"],
   nsSeparator: ":",
-  returnEmptyString: false,
+  returnEmptyString: true,
   defaultNS: "default",
   fallbackNS: ["fields", "pages"],
   backend: {
@@ -106,6 +106,8 @@ var i18nextConfigurationOptions = {
 };
 
 const configureI18next = (config) => {
+  console.log(">>>>>>> configureI18next");
+
   const i18next = require("i18next");
   const Backend = require("i18next-sync-fs-backend");
   const i18nextMiddleware = require("i18next-http-middleware");
@@ -150,6 +152,24 @@ router.use("/oauth2", commonExpress.routes.oauth2);
 router.use("/previous", require("./app/address/routes/previous"));
 router.use("/", require("./app/address/routes/address"));
 router.use("/summary", require("./app/address/routes/summary"));
+
+router.use("/debug", (req, res, next) => {
+  // return res.sendStatus(200);
+  const data = {
+    "req.translate": req.translate("validation.required", { label: "LABEL" }),
+    "req.i18n.language": req.i18n?.language,
+    "req.i18n.resolvedLanguage": req.i18n?.resolvedLanguage,
+    "req.i18n.t_addressSelect.addressFoundWithCount": req.i18n.t(
+      "addressSelect.addressFoundWithCount",
+      {
+        namespace: "default",
+        count: 1,
+      }
+    ),
+  };
+
+  res.json(data);
+});
 
 router.use("^/$", (req, res) => {
   res.render("index");

--- a/src/app.js
+++ b/src/app.js
@@ -82,17 +82,27 @@ const { app, router } = setup({
 });
 
 var i18nextConfigurationOptions = {
-  debug: false,
+  debug: true,
   initImmediate: true,
   supportedLngs: ["en", "cy"],
-  fallbackLng: ["en"],
+  // fallbackLng: ["en"],
   preload: ["en", "cy"],
   ns: ["default", "fields", "pages"],
+  nsSeparator: ":",
+  returnEmptyString: false,
   defaultNS: "default",
+  fallbackNS: ["fields", "pages"],
   backend: {
     loadPath: "./src/locales/{{lng}}/{{ns}}.yml",
   },
   saveMissingTo: "current",
+  detection: {
+    order: ["querystring", "cookie"],
+    caches: ["cookie"],
+    cookieMinutes: 160,
+    lookupQuerystring: "lng",
+    lookupCookie: "lng",
+  },
 };
 
 const configureI18next = (config) => {

--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -18,45 +18,45 @@ class AddressResultsController extends BaseController {
       // console.log(Object.keys(req.translate));
       // console.log(Object.keys(req.i18n?.t));
 
-      req.translate = req.i18n.t;
+      // req.translate = req.i18n.t;
 
-      debug(req.translate("validation.required", { label: "LABEL" }));
-      debug(`language: ${req.i18n?.language}`);
-      debug(`resolvedLanguage: ${req.i18n?.resolvedLanguage}`);
-      debug(req.i18n.getFixedT("cy"));
-      debug(req.i18n.getFixedT("en")("buttons.next"));
-      debug(req.i18n.getFixedT("cy")("buttons.next"));
-      debug(
-        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_one")
-      );
-      debug(
-        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_other")
-      );
-      debug(
-        req.i18n.t("addressSelect.addressFoundWithCount", {
-          count: 2,
-        })
-      );
-      debug(
-        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount", {
-          count: 2,
-        })
-      );
-
-      debug(
-        req.i18n.t("addressSelect.addressFoundWithCount", {
-          namespace: "default",
-          count: 2,
-        })
-      );
-
-      // console.log(Object.keys(req.i18n?.translate));
-      debug(Object.keys(req.i18n).sort());
+      // debug(req.translate("validation.required", { label: "LABEL" }));
+      // debug(`language: ${req.i18n?.language}`);
+      // debug(`resolvedLanguage: ${req.i18n?.resolvedLanguage}`);
+      // debug(req.i18n.getFixedT("cy"));
+      // debug(req.i18n.getFixedT("en")("buttons.next"));
+      // debug(req.i18n.getFixedT("cy")("buttons.next"));
+      // debug(
+      //   req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_one")
+      // );
+      // debug(
+      //   req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_other")
+      // );
+      // debug(
+      //   req.i18n.t("addressSelect.addressFoundWithCount", {
+      //     count: 2,
+      //   })
+      // );
+      // debug(
+      //   req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount", {
+      //     count: 2,
+      //   })
+      // );
+      //
+      // debug(
+      //   req.i18n.t("addressSelect.addressFoundWithCount", {
+      //     namespace: "default",
+      //     count: 2,
+      //   })
+      // );
+      //
+      // // console.log(Object.keys(req.i18n?.translate));
+      // debug(Object.keys(req.i18n).sort());
 
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addresses = presenters.addressesToSelectItems({
         addresses: req.sessionModel.get("searchResults"),
-        translate: req.i18n.t,
+        translate: req.translate,
       });
 
       callback(null, locals);

--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -13,6 +13,24 @@ class AddressResultsController extends BaseController {
         callback(err, locals);
       }
 
+      // console.log(Object.keys(req.translate));
+      // console.log(Object.keys(req.i18n?.t));
+
+      req.translate = req.i18n.t;
+
+      console.log(req.translate("validation.required", { label: "LABEL" }));
+      console.log(req.i18n?.language);
+      console.log(req.i18n?.resolvedLanguage);
+      console.log(
+        req.translate("addressSelect.addressFoundWithCount", {
+          namespace: "default",
+          count: 2,
+        })
+      );
+
+      // console.log(Object.keys(req.i18n?.translate));
+      console.log(Object.keys(req.i18n).sort());
+
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addresses = presenters.addressesToSelectItems({
         addresses: req.sessionModel.get("searchResults"),

--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -2,12 +2,23 @@ const {
   addressSelectorValidator,
 } = require("../../validators/addressSelectorValidation");
 
+const presenters = require("../../presenters");
+
 const BaseController = require("hmpo-form-wizard").Controller;
 
 class AddressResultsController extends BaseController {
   locals(req, res, callback) {
     super.locals(req, res, (err, locals) => {
+      if (err) {
+        callback(err, locals);
+      }
+
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
+      locals.addresses = presenters.addressesToSelectItems({
+        addresses: req.sessionModel.get("searchResults"),
+        translate: req.translate,
+      });
+
       callback(null, locals);
     });
   }
@@ -38,11 +49,9 @@ class AddressResultsController extends BaseController {
 
         const chosenAddress = this.getAddress(selectedAddress, searchResults);
 
-        delete chosenAddress.value;
-        delete chosenAddress.text;
-
         req.sessionModel.set("checkDetailsHeader", true);
         req.sessionModel.set("address", chosenAddress);
+
         callback();
       } catch (err) {
         callback(err);
@@ -53,7 +62,11 @@ class AddressResultsController extends BaseController {
   getAddress(selectedAddress, searchResults) {
     const chosenAddress = Object.assign(
       {},
-      searchResults.find((address) => address.text === selectedAddress)
+      searchResults.find(
+        (address) =>
+          presenters.addressPresenter.generateSearchResultString(address) ===
+          selectedAddress
+      )
     );
 
     return chosenAddress;

--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -16,7 +16,7 @@ class AddressResultsController extends BaseController {
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addresses = presenters.addressesToSelectItems({
         addresses: req.sessionModel.get("searchResults"),
-        translate: req.translate,
+        translate: req.i18n.t,
       });
 
       callback(null, locals);

--- a/src/app/address/controllers/address/results.js
+++ b/src/app/address/controllers/address/results.js
@@ -1,3 +1,5 @@
+const debug = require("debug")("address");
+
 const {
   addressSelectorValidator,
 } = require("../../validators/addressSelectorValidation");
@@ -18,18 +20,38 @@ class AddressResultsController extends BaseController {
 
       req.translate = req.i18n.t;
 
-      console.log(req.translate("validation.required", { label: "LABEL" }));
-      console.log(req.i18n?.language);
-      console.log(req.i18n?.resolvedLanguage);
-      console.log(
-        req.translate("addressSelect.addressFoundWithCount", {
+      debug(req.translate("validation.required", { label: "LABEL" }));
+      debug(`language: ${req.i18n?.language}`);
+      debug(`resolvedLanguage: ${req.i18n?.resolvedLanguage}`);
+      debug(req.i18n.getFixedT("cy"));
+      debug(req.i18n.getFixedT("en")("buttons.next"));
+      debug(req.i18n.getFixedT("cy")("buttons.next"));
+      debug(
+        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_one")
+      );
+      debug(
+        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount_other")
+      );
+      debug(
+        req.i18n.t("addressSelect.addressFoundWithCount", {
+          count: 2,
+        })
+      );
+      debug(
+        req.i18n.getFixedT("cy")("addressSelect.addressFoundWithCount", {
+          count: 2,
+        })
+      );
+
+      debug(
+        req.i18n.t("addressSelect.addressFoundWithCount", {
           namespace: "default",
           count: 2,
         })
       );
 
       // console.log(Object.keys(req.i18n?.translate));
-      console.log(Object.keys(req.i18n).sort());
+      debug(Object.keys(req.i18n).sort());
 
       locals.addressPostcode = req.sessionModel.get("addressPostcode");
       locals.addresses = presenters.addressesToSelectItems({

--- a/src/app/address/controllers/address/results.test.js
+++ b/src/app/address/controllers/address/results.test.js
@@ -1,6 +1,8 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const AddressResultController = require("./results");
 
+const presenters = require("../../presenters");
+
 const testData = require("../../../../../test/data/testData");
 
 let req;
@@ -8,51 +10,133 @@ let res;
 let next;
 let sandbox;
 
-beforeEach(() => {
-  sandbox = sinon.createSandbox();
-  const setup = setupDefaultMocks();
-  req = setup.req;
-  res = setup.res;
-  next = setup.next;
-});
-
-afterEach(() => {
-  sandbox.restore();
-});
-
 describe("Address result controller", () => {
   let addressResult;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const setup = setupDefaultMocks();
+    req = setup.req;
+    req.i18n = {
+      t: sinon.stub(),
+    };
+
+    res = setup.res;
+    next = setup.next;
+
+    sinon.stub(presenters, "addressesToSelectItems");
+
     addressResult = new AddressResultController({ route: "/test" });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    presenters.addressesToSelectItems.restore();
   });
 
   it("should be an instance of BaseController", () => {
     expect(addressResult).to.be.an.instanceOf(BaseController);
   });
 
-  it("Should set the chosen address in the session", async () => {
-    const expectedResponse = testData.formattedAddressed[1];
+  describe("#locals", () => {
+    let prototypeSpy;
 
-    req.form.values.addressResults = expectedResponse.value;
+    beforeEach(() => {
+      prototypeSpy = sinon.stub(BaseController.prototype, "locals");
+      BaseController.prototype.locals.callThrough();
 
-    req.sessionModel.set("searchResults", testData.formattedAddressed);
+      req.sessionModel.set("addressPostcode", "E1 8QS");
+      req.sessionModel.set("searchResults", [
+        { postcode: "Q1 1AB" },
+        { postcode: "Q2 2AB" },
+      ]);
 
-    await addressResult.saveValues(req, res, next);
+      presenters.addressesToSelectItems.returns([
+        { text: "nn addresses found", value: "" },
+      ]);
+    });
 
-    expect(next).to.have.been.calledOnce;
-    expect(req.session.test.address.buildingNumber).to.equal(
-      expectedResponse.buildingNumber
-    );
+    afterEach(() => {
+      prototypeSpy.restore();
+    });
 
-    expect(req.session.test.address.streetName).to.equal(
-      expectedResponse.streetName
-    );
-    expect(req.session.test.address.postCode).to.equal(
-      expectedResponse.postCode
-    );
-    expect(req.session.test.address.postTown).to.equal(
-      expectedResponse.postTown
-    );
+    it("should call locals first with a callback", () => {
+      addressResult.locals(req, res, next);
+
+      expect(prototypeSpy).to.have.been.calledBefore(next);
+    });
+
+    it("should add postcode from session into locals", () => {
+      addressResult.locals(req, res, next);
+
+      expect(next).to.have.been.calledWith(
+        null,
+        sinon.match({ addressPostcode: "E1 8QS" })
+      );
+    });
+
+    it("should add addres as select items data into locals", () => {
+      presenters.addressesToSelectItems.returns([
+        { text: "nn addresses found", value: "" },
+      ]);
+
+      addressResult.locals(req, res, next);
+
+      expect(next).to.have.been.calledWith(
+        null,
+        sinon.match({ addresses: [{ text: "nn addresses found", value: "" }] })
+      );
+    });
+    context("with error on callback", () => {
+      let error;
+      let locals;
+      let superLocals;
+
+      beforeEach(async () => {
+        error = new Error("Random error");
+        superLocals = {
+          superKey: "superValue",
+        };
+
+        locals = {
+          key: "value",
+        };
+        res.locals = locals;
+        BaseController.prototype.locals.yields(error, superLocals);
+
+        await addressResult.locals(req, res, next);
+      });
+
+      it("should call callback with error and existing locals", () => {
+        expect(next).to.have.been.calledWith(error, superLocals);
+      });
+    });
+  });
+
+  describe("#saveValues", () => {
+    it("Should set the chosen address in the session", async () => {
+      const expectedResponse = testData.formattedAddressed[1];
+
+      req.form.values.addressResults = expectedResponse.value;
+
+      req.sessionModel.set("searchResults", testData.formattedAddressed);
+
+      await addressResult.saveValues(req, res, next);
+
+      expect(next).to.have.been.calledOnce;
+      expect(req.session.test.address.buildingNumber).to.equal(
+        expectedResponse.buildingNumber
+      );
+
+      expect(req.session.test.address.streetName).to.equal(
+        expectedResponse.streetName
+      );
+      expect(req.session.test.address.postCode).to.equal(
+        expectedResponse.postCode
+      );
+      expect(req.session.test.address.postTown).to.equal(
+        expectedResponse.postTown
+      );
+    });
   });
 });

--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -1,7 +1,3 @@
-const {
-  generateSearchResultString,
-} = require("../../presenters/addressPresenter");
-
 const BaseController = require("hmpo-form-wizard").Controller;
 
 const {
@@ -41,17 +37,9 @@ class AddressSearchController extends BaseController {
     const addressResults = await axios.get(`${POSTCODE_LOOKUP}/${postcode}`, {
       headers,
     });
-    const addresses = addressResults.data.map((address) => {
-      const textView = generateSearchResultString(address);
-      return { ...address, text: textView, value: textView };
-    });
+    const addresses = addressResults.data;
 
-    const defaultMessage = {
-      text: `${addresses.length} addresses found`,
-      value: "",
-    };
-
-    return [defaultMessage, ...addresses];
+    return addresses;
   }
 }
 

--- a/src/app/address/controllers/address/search.test.js
+++ b/src/app/address/controllers/address/search.test.js
@@ -56,25 +56,11 @@ describe("Address Search controller", () => {
           },
         }
       );
-      expect(req.session.test.searchResults[0]).to.deep.equal({
-        text: `${testData.apiResponse.data.length} addresses found`,
-        value: "",
-      });
-      expect(req.session.test.addressPostcode).to.equal(testPostcode);
 
-      // test each object matches the expected response in testData
-      req.session.test.searchResults.forEach((searchResult, index) => {
-        // first result should be a summary.
-        if (index === 0) {
-          expect(searchResult.text).to.equal(
-            `${testData.apiResponse.data.length} addresses found`
-          );
-        } else {
-          expect(searchResult).to.deep.equal(
-            testData.formattedAddressed[index - 1]
-          );
-        }
-      });
+      expect(req.session.test.searchResults).to.deep.equal(
+        testData.apiResponse.data
+      );
+
       expect(req.session.test.requestIsSuccessful).to.equal(true);
     });
 

--- a/src/app/address/presenters/addressesToSelectItems.js
+++ b/src/app/address/presenters/addressesToSelectItems.js
@@ -1,0 +1,20 @@
+const { generateSearchResultString } = require("./addressPresenter");
+
+module.exports = ({ addresses }) => {
+  const defaultMessage = {
+    text: `${addresses.length} addresses found`,
+    value: "",
+  };
+
+  if (!addresses || addresses.length <= 0) {
+    return [defaultMessage];
+  }
+
+  const addressesAsItems = addresses.map((address) => {
+    const textView = generateSearchResultString(address);
+
+    return { ...address, text: textView, value: textView };
+  });
+
+  return [defaultMessage, ...addressesAsItems];
+};

--- a/src/app/address/presenters/addressesToSelectItems.js
+++ b/src/app/address/presenters/addressesToSelectItems.js
@@ -1,8 +1,10 @@
 const { generateSearchResultString } = require("./addressPresenter");
 
-module.exports = ({ addresses }) => {
+module.exports = ({ addresses, translate }) => {
   const defaultMessage = {
-    text: `${addresses.length} addresses found`,
+    text: translate("addressSelect.addressFoundWithCount", {
+      count: addresses.length,
+    }),
     value: "",
   };
 

--- a/src/app/address/presenters/addressesToSelectItems.test.js
+++ b/src/app/address/presenters/addressesToSelectItems.test.js
@@ -1,0 +1,69 @@
+const { expect } = require("chai");
+const presenter = require("./addressesToSelectItems");
+
+const addressPresenter = require("./addressPresenter");
+
+describe("Addresses to SelectItems Presenter", () => {
+  let translate;
+
+  beforeEach(() => {
+    translate = sinon.stub();
+
+    sinon
+      .stub(addressPresenter, "generateSearchResultString")
+      .returns("SEARCH_RESULT");
+  });
+
+  afterEach(() => {
+    addressPresenter.generateSearchResultString.restore();
+  });
+
+  it("should use a default message for 0 items", () => {
+    const addresses = [];
+
+    presenter({ addresses, translate });
+
+    expect(translate).to.have.been.calledWith(
+      "addressSelect.addressFoundWithCount",
+      { count: 0 }
+    );
+  });
+
+  it("should use a addressesFound message for 1 item", () => {
+    const addresses = [{}];
+
+    presenter({ addresses, translate });
+
+    expect(translate).to.have.been.calledWith(
+      "addressSelect.addressFoundWithCount",
+      { count: 1 }
+    );
+  });
+
+  it("should return items from addresses", () => {
+    const addresses = [
+      {
+        streetName: "street",
+        addressLocality: "locality",
+        buildingNumber: "00",
+        postalCode: "Q1 1JK",
+      },
+    ];
+
+    translate.returns("addressSelect.addressFoundWithCount");
+
+    const items = presenter({ addresses, translate });
+
+    expect(items).to.deep.equal([
+      { text: "addressSelect.addressFoundWithCount", value: "" },
+      {
+        addressLocality: "locality",
+        buildingNumber: "00",
+        postalCode: "Q1 1JK",
+        streetName: "street",
+        text: "00 street, locality, Q1 1JK",
+        value: "00 street, locality, Q1 1JK",
+      },
+    ]);
+  });
+});

--- a/src/app/address/presenters/index.js
+++ b/src/app/address/presenters/index.js
@@ -1,0 +1,7 @@
+const addressesToSelectItems = require("./addressesToSelectItems");
+const addressPresenter = require("./addressPresenter");
+
+module.exports = {
+  addressPresenter,
+  addressesToSelectItems,
+};

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,5 +1,6 @@
 const i18next = require("i18next");
 const Backend = require("i18next-sync-fs-backend");
+const i18nextMiddleware = require("i18next-http-middleware");
 
 // const interpolation = require("./interpolation");
 
@@ -16,4 +17,53 @@ i18next.use(Backend).init({
   },
 });
 
-module.exports = i18next;
+var i18nextConfigurationOptions = {
+  debug: true,
+  initImmediate: false,
+  supportedLngs: ["en", "cy"],
+  // fallbackLng: ["en"],
+  preload: ["en", "cy"],
+  ns: ["default", "fields", "pages", "pages.errors"],
+  nsSeparator: ".",
+  returnEmptyString: true,
+  defaultNS: "default",
+  fallbackNS: ["fields", "pages", "pages.errors"],
+  backend: {
+    loadPath: "./src/locales/{{lng}}/{{ns}}.yml",
+  },
+  saveMissingTo: "current",
+  detection: {
+    order: ["querystring", "cookie"],
+    caches: ["cookie"],
+    cookieMinutes: 160,
+    lookupQuerystring: "lng",
+    lookupCookie: "lng",
+  },
+};
+
+const configure = ({ app }) => {
+  const configureI18next = (config) => {
+    console.log(">>>>>>> configureI18next");
+
+    const i18next = require("i18next");
+    const Backend = require("i18next-sync-fs-backend");
+    const i18nextMiddleware = require("i18next-http-middleware");
+
+    i18next.use(Backend).use(i18nextMiddleware.LanguageDetector).init(config);
+
+    return i18nextMiddleware.handle(i18next, {
+      ignoreRoutes: ["/public"], // or function(req, res, options, i18next) { /* return true to ignore */ }
+    });
+  };
+  // router.use(configureI18next(i18nextConfigurationOptions));
+  app.use(configureI18next(i18nextConfigurationOptions));
+  app.use((req, res, next) => {
+    req.translate = req.i18n.getFixedT(req.i18n.language);
+    next();
+  });
+};
+
+module.exports = {
+  i18next,
+  configure,
+};

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,0 +1,19 @@
+const i18next = require("i18next");
+const Backend = require("i18next-sync-fs-backend");
+
+// const interpolation = require("./interpolation");
+
+i18next.use(Backend).init({
+  initImmediate: false,
+  lng: "en",
+  fallbackLng: "en",
+  preload: ["en"],
+  nsSeparator: "::",
+  defaultNS: "default",
+  ns: ["default", "fields", "pages"],
+  backend: {
+    loadPath: "./locales/{{lng}}/{{ns}}.yaml",
+  },
+});
+
+module.exports = i18next;

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -83,5 +83,8 @@ validation:
   alphaNumericWithSpecialChars: "Ni ddylai eich {{ label }} gynnwys unrhyw nodau neu symbolau arbennig"
   default: "Mae'n rhaid i chi ateb y cwestiwn hwn"
 addressSelect:
-  "addressFoundWithCount_one": "{{ count }} address found but in Welsh"
-  "addressFoundWithCount_other": "{{ count }} addresses found but in Welsh"
+  addressFoundWithCount_one: "{{ count }} address found in Welsh"
+  addressFoundWithCount_two: "{{ count }} addresses found in Welsh x2"
+  addressFoundWithCount_few: "{{ count }} addresses found in Welsh x3"
+  addressFoundWithCount_many: "{{ count }} addresses found in Welsh x6"
+  addressFoundWithCount_other: "{{ count }} addresses found in Welsh x42"

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -82,3 +82,6 @@ validation:
   isUkPostcode: "Rhowch god post yn y DU"
   alphaNumericWithSpecialChars: "Ni ddylai eich {{ label }} gynnwys unrhyw nodau neu symbolau arbennig"
   default: "Mae'n rhaid i chi ateb y cwestiwn hwn"
+addressSelect:
+  "addressFoundWithCount_one": "{{ count }} address found but in Welsh"
+  "addressFoundWithCount_other": "{{ count }} addresses found but in Welsh"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -50,7 +50,6 @@ govuk:
     text: "© Crown copyright"
   contentLicence:
     html: 'All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="licence">Open Government Licence v3.0</a>, except where otherwise stated'
-
 error:
   unrecoverable:
     title: Sorry, there is a problem with the service
@@ -60,7 +59,6 @@ error:
     contactMeLink: Contact the GOV.UK account team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
-
 links:
   changeAddress: <a href="/address/edit" id="change-address" data-id="changeAddress" class="govuk-link">Change<span class="govuk-visually-hidden"> your current address</span></a>
   changeYearFrom: <a href="/address/edit" id="change-address" data-id="changeAddress" class="govuk-link">Change<span class="govuk-visually-hidden"> the year you started living at your current address</span></a>
@@ -85,5 +83,5 @@ validation:
   alphaNumericWithSpecialChars: Your {{ label }} should not include any special characters or symbols
   default: You must answer this question
 addressSelect:
-  "addressFoundWithCount_one": "{{ count }} address found in English"
-  "addressFoundWithCount_other": "{{ count }} addresses found in English"
+  addressFoundWithCount_one: "{{ count }} address found in English"
+  addressFoundWithCount_other: "{{ count }} addresses found in English x2"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -85,5 +85,5 @@ validation:
   alphaNumericWithSpecialChars: Your {{ label }} should not include any special characters or symbols
   default: You must answer this question
 addressSelect:
-  "addressFoundWithCount_one": "{{ count }} address found"
-  "addressFoundWithCount_other": "{{ count }} addresses found"
+  "addressFoundWithCount_one": "{{ count }} address found in English"
+  "addressFoundWithCount_other": "{{ count }} addresses found in English"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -84,3 +84,6 @@ validation:
   isUkPostcode: "Enter a UK postcode"
   alphaNumericWithSpecialChars: Your {{ label }} should not include any special characters or symbols
   default: You must answer this question
+addressSelect:
+  "addressFoundWithCount_one": "{{ count }} address found"
+  "addressFoundWithCount_other": "{{ count }} addresses found"

--- a/src/views/address/address.html
+++ b/src/views/address/address.html
@@ -16,7 +16,7 @@
      <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.title")}}</h1>
   {% endif %}
 
-  {{hmpoHtml(translate("links.changePostcode"))}}
+  {{hmpoHtml(translate("links.changePostcode", { returnObjects: true }))}}
 
   {% call hmpoForm(ctx) %}
 

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -8,15 +8,15 @@
 
 {% block mainContent %}
 
-  <h1 id="header" class="govuk-heading-l">{{translate("pages:address-results.title")}}</h1>
+  <h1 id="header" class="govuk-heading-l">{{translate("pages.address-results.title")}}</h1>
 
-  {{hmpoHtml(translate("links.changePostcode"))}}
+  {{hmpoHtml(translate("links.changePostcode", { returnObjects: true }))}}
 
   {% call hmpoForm(ctx) %}
 
     {{ hmpoSelect(ctx, {
       id: "addressResults",
-      label: translate("fields:addressResults.label"),
+      label: translate("fields.addressResults.label"),
       hint: "",
       items: addresses
     }) }}

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -8,7 +8,7 @@
 
 {% block mainContent %}
 
-  <h1 id="header" class="govuk-heading-l">{{translate("pages.address-results.title")}}</h1>
+  <h1 id="header" class="govuk-heading-l">{{translate("pages:address-results.title")}}</h1>
 
   {{hmpoHtml(translate("links.changePostcode"))}}
 
@@ -16,11 +16,12 @@
 
     {{ hmpoSelect(ctx, {
       id: "addressResults",
-      label: translate("fields.addressResults.label"),
+      label: translate("fields:addressResults.label"),
+      hint: "",
       items: addresses
     }) }}
 
-    {{ hmpoHtml(translate("links.cantFindAddress")) }}
+    {{ hmpoHtml(translate("links.cantFindAddress", { returnObjects: true })) }}
 
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.select-address")}) }}
 

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -17,7 +17,7 @@
     {{ hmpoSelect(ctx, {
       id: "addressResults",
       label: translate("fields.addressResults.label"),
-      items: values.searchResults
+      items: addresses
     }) }}
 
     {{ hmpoHtml(translate("links.cantFindAddress")) }}

--- a/src/views/components/address-problem-field.html
+++ b/src/views/components/address-problem-field.html
@@ -4,7 +4,7 @@
 <h1 id="header" class="govuk-heading-l">{{translate("pages.addressProblem.title")}}</h1>
 {% call hmpoForm(ctx) %}
 
-  {{hmpoHtml(translate("pages.addressProblem.content"))}}
+  {{hmpoHtml(translate("pages.addressProblem.content", { returnObjects: true }))}}
 
   {{ hmpoRadios(ctx, {
       id: "addressBreak",
@@ -19,6 +19,6 @@
 
   {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
 
- {{hmpoHtml(translate("links.helpContact"))}}
+ {{hmpoHtml(translate("links.helpContact", { returnObjects: true }))}}
 
 {% endcall %}

--- a/src/views/previous/address.html
+++ b/src/views/previous/address.html
@@ -14,7 +14,7 @@
       <h1 id="header" class="govuk-heading-l">{{translate("pages.address-form.previous.title")}}</h1>
     {% endif %}
 
-  {{hmpoHtml(translate("links.previous.changePostcode"))}}
+  {{hmpoHtml(translate("links.previous.changePostcode", { returnObjects: true }))}}
 
   {% call hmpoForm(ctx) %}
 

--- a/src/views/previous/results.html
+++ b/src/views/previous/results.html
@@ -18,7 +18,7 @@
     {{ hmpoSelect(ctx, {
       id: "addressResults",
       label: translate("fields.addressResultsPrevious.label"),
-      items: values.searchResults
+      items: addresses
     }) }}
 
     {{ hmpoHtml(translate("links.previous.cantFindAddress")) }}

--- a/src/views/previous/results.html
+++ b/src/views/previous/results.html
@@ -11,7 +11,7 @@
 
   <h1 id="header" class="govuk-heading-l">{{translate("pages.address-previous-results.title")}}</h1>
 
-  {{hmpoHtml(translate("links.previous.changePostcode"))}}
+  {{hmpoHtml(translate("links.previous.changePostcode", { returnObjects: true }))}}
 
   {% call hmpoForm(ctx) %}
 
@@ -21,7 +21,7 @@
       items: addresses
     }) }}
 
-    {{ hmpoHtml(translate("links.previous.cantFindAddress")) }}
+    {{ hmpoHtml(translate("links.previous.cantFindAddress", { returnObjects: true })) }}
 
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.select-address")}) }}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,6 +2518,19 @@ i18next-fs-backend@^1.1.5:
   resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.5.tgz#dcbd8227b1c1e4323b3c40e269d4762e8313d9e5"
   integrity sha512-raTel3EfshiUXxR0gvmIoqp75jhkj8+7R1LjB006VZKPTFBbXyx6TlUVhb8Z9+7ahgpFbcQg1QWVOdf/iNzI5A==
 
+i18next-http-middleware@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/i18next-http-middleware/-/i18next-http-middleware-3.2.1.tgz#a0dff150de2273ec650da67336ad882eef58d179"
+  integrity sha512-zBwXxDChT0YLoTXIR6jRuqnUUhXW0Iw7egoTnNXyaDRtTbfWNXwU0a53ThyuRPQ+k+tXu3ZMNKRzfLuononaRw==
+
+i18next-sync-fs-backend@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/i18next-sync-fs-backend/-/i18next-sync-fs-backend-1.1.1.tgz#d1fb28545918e899b59feccc61adb4b9f5593a04"
+  integrity sha512-IoJCGid/NLqPFp+2qsumwOy1hG6jENKSIW9BozHL/3ZsjunH0P7iZLRMADljIuFntKlA63suPIPJWGR2SkxLIg==
+  dependencies:
+    js-yaml "3.13.1"
+    json5 "0.5.0"
+
 i18next@^21.9.1:
   version "21.9.1"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.9.1.tgz#9e3428990f5b2cc9ac1b98dd025f3e411c368249"
@@ -2909,6 +2922,14 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@4.0.x:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
@@ -2955,6 +2976,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json5@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.0.tgz#9b20715b026cbe3778fd769edccd822d8332a5b2"
+  integrity sha512-WDgahySBucTVnQuzQHoVh6BKKg3TFBUExSwYOPwA4it9xtspn3erHYkdEx1AXXkHN38L7O6v6lmqLiXh/GnxhA==
 
 json5@^2.1.2, json5@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This is a working spike on 
- refactoring address results to use a presenter pattern with a translate function, instead of language strings in code
- replacing hmpo-i18n with i18next to use plurals, nesting, and cookie domains

It will need to be harvested into separate PRs, with the common code ultimately ending up in `common-express`


### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
