### PR TITLE
Oj 913/use i18next

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ const setAxiosDefaults = commonExpress.lib.axios;
 const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
 const { setGTM } = require("di-ipv-cri-common-express/src/lib/settings");
 const { getGTM } = require("di-ipv-cri-common-express/src/lib/locals");
+const { setI18n } = require("di-ipv-cri-common-express/src/lib/i18next");
 
 const {
   API,
@@ -80,6 +81,8 @@ const { app, router } = setup({
   },
   dev: true,
 });
+
+setI18n({ app });
 
 app.get("nunjucks").addGlobal("getContext", function () {
   return {

--- a/src/views/address/results.html
+++ b/src/views/address/results.html
@@ -17,6 +17,7 @@
     {{ hmpoSelect(ctx, {
       id: "addressResults",
       label: translate("fields.addressResults.label"),
+      hint: "",
       items: values.searchResults
     }) }}
 

--- a/src/views/components/address-input-fields.html
+++ b/src/views/components/address-input-fields.html
@@ -5,33 +5,38 @@
   id: "addressFlatNumber",
   name: "addressFlatNumber",
   label: { text: translate("fields.addressFlatNumber.label") },
-  classes: "govuk-input--width-5"
+  classes: "govuk-input--width-5",
+  hint: ""
 }) }}
 
 {{ hmpoText(ctx, {
   id: "addressHouseNumber",
   name: "addressHouseNumber",
   label: { text: translate("fields.addressHouseNumber.label") },
-  classes: "govuk-input--width-5"
+  classes: "govuk-input--width-5",
+  hint: ""
 }) }}
 
 {{ hmpoText(ctx, {
   id: "addressHouseName",
   name: "addressHouseName",
   label: { text: translate("fields.addressHouseName.label") },
-  classes: "govuk-input--width-20"
+  classes: "govuk-input--width-20",
+  hint: ""
 }) }}
 
 {{ hmpoText(ctx,{
   id: "addressStreetName",
   name: "addressStreetName",
   label: { text: translate("fields.addressStreetName.label") },
-  classes: "govuk-input--width-20"
+  classes: "govuk-input--width-20",
+  hint: ""
 }) }}
 
 {{ hmpoText(ctx, {
   id: "addressLocality",
   name: "addressLocality",
   label: { text: translate("fields.addressLocality.label") },
-  classes: "govuk-input--width-20"
+  classes: "govuk-input--width-20",
+  hint: ""
 }) }}

--- a/src/views/components/address-problem-field.html
+++ b/src/views/components/address-problem-field.html
@@ -11,8 +11,10 @@
       name: "addressBreak",
       value: "addressBreak",
       legend: {
-        classes: ["govuk-fieldset__legend--s"]
+        classes: ["govuk-fieldset__legend--s"],
+        text: ""
       },
+      hint: "",
       fields: addressBreak.items
     })
   }}

--- a/src/views/components/address-year-from-field.html
+++ b/src/views/components/address-year-from-field.html
@@ -6,5 +6,6 @@
   id: "addressYearFrom",
   name: "addressYearFrom",
   label: { text: translate("fields.addressYearFrom.label")},
-  classes: "govuk-input--width-4"
+  classes: "govuk-input--width-4",
+  hint: ""
 }) }}

--- a/src/views/previous/results.html
+++ b/src/views/previous/results.html
@@ -18,6 +18,7 @@
     {{ hmpoSelect(ctx, {
       id: "addressResults",
       label: translate("fields.addressResultsPrevious.label"),
+      hint: "",
       items: values.searchResults
     }) }}
 

--- a/src/views/summary/confirm.html
+++ b/src/views/summary/confirm.html
@@ -141,6 +141,7 @@
         label: {
           classes: ["govuk-fieldset__legend--s"]
         },
+        legend: translate("fields.isAddressMoreThanThreeMonths.label"),
         fields: isAddressMoreThanThreeMonths.items
       }) }}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Switch from using hmpo-i18n to i18next so that we can take advantage of cookie domains and interpolation.

This PR uses the i18next middleware exported from common-express, and updates templates with the minimal changes required to use the new library.

It does not contain any of the cookie domain or interpolation features.

It requires [common-express #109](https://github.com/alphagov/di-ipv-cri-common-express/pull/109) to be merged first, and the temporary dependency commit to be dropped.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-913](https://govukverify.atlassian.net/browse/OJ-913)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
