### PR TITLE
Use router instead of app with i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.5",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.33",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.34",
     "dotenv": "16.0.3",
     "express": "4.18.2",
     "express-async-errors": "3.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,7 @@ const { app, router } = setup({
   dev: true,
 });
 
-setI18n({ app });
+setI18n({ router });
 
 app.get("nunjucks").addGlobal("getContext", function () {
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,10 +1454,9 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.33:
-  version "0.0.33"
-  uid "5f17615b23114262b88e48e253e058163bdf0a0a"
-  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/5f17615b23114262b88e48e253e058163bdf0a0a"
+di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.34:
+  version "0.0.34"
+  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/467007b013b0d07cff5cad0ed2c21b7d0e658821"
   dependencies:
     hmpo-logger "6.1.1"
     i18next "21.10.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update setI18n call to pass through the main `router` not  the `app` so that middleware can be attached correctly.

This should fix the issue with the "missing" translation key.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
