### PR TITLE
OJ 991 - Make Street name optional on Address journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/src/app/address/routes/sharedFields.js
+++ b/src/app/address/routes/sharedFields.js
@@ -88,9 +88,6 @@ module.exports = {
     type: "text",
     validate: [
       {
-        type: "required",
-      },
-      {
         type: "maxlength",
         fn: "maxlength",
         arguments: [60],

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -3,7 +3,7 @@ module.exports = {
     const { buildingNames, streetNames, localityNames } =
       extractAddressFields(address);
     const fullBuildingName = buildingNames.join(" ");
-    var fullStreetName;
+    let fullStreetName;
     if (streetNames) {
       fullStreetName = streetNames.join(" ");
     }
@@ -20,7 +20,7 @@ module.exports = {
       extractAddressFields(address);
 
     const fullBuildingName = buildingNames.join(" ");
-    var fullStreetName;
+    let fullStreetName;
     if (streetNames) {
       fullStreetName = streetNames.join(" ");
     }

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -3,23 +3,35 @@ module.exports = {
     const { buildingNames, streetNames, localityNames } =
       extractAddressFields(address);
     const fullBuildingName = buildingNames.join(" ");
-    const fullStreetName = streetNames.join(" ");
-    const fullLocality = localityNames.join(" ");
-    const text = `${fullBuildingName} ${fullStreetName}, ${fullLocality}, ${address.postalCode}`;
+    var fullStreetName;
+    if (streetNames) {
+      fullStreetName = streetNames.join(" ");
+    }
 
-    return text;
+    const fullLocality = localityNames.join(" ");
+    if (fullStreetName) {
+      return `${fullBuildingName} ${fullStreetName}, ${fullLocality}, ${address.postalCode}`;
+    } else {
+      return `${fullBuildingName}, ${fullLocality}, ${address.postalCode}`;
+    }
   },
   generateHTMLofAddress: function (address) {
     const { buildingNames, streetNames, localityNames } =
       extractAddressFields(address);
 
     const fullBuildingName = buildingNames.join(" ");
-    const fullStreetName = streetNames.join(" ");
+    var fullStreetName;
+    if (streetNames) {
+      fullStreetName = streetNames.join(" ");
+    }
+
     const fullLocality = localityNames.join(" ");
 
-    const text = `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
-
-    return text;
+    if (fullStreetName) {
+      return `${fullBuildingName}<br>${fullStreetName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+    } else {
+      return `${fullBuildingName},<br>${fullLocality},<br>${address.postalCode}<br>`;
+    }
   },
 };
 

--- a/src/presenters/addressPresenter.test.js
+++ b/src/presenters/addressPresenter.test.js
@@ -5,58 +5,116 @@ const {
 } = require("./addressPresenter");
 
 describe("Address Presenter", () => {
-  describe("generateSearchResultString", () => {
-    const data = [
-      {
-        address: {
-          organisationName: "My company",
-          departmentName: "My department",
-          buildingName: "my building",
-          subBuildingName: "Room 5",
-          buildingNumber: "1",
-          dependentStreetName: "My outer street",
-          streetName: "my inner street",
-          doubleDependentAddressLocality: "My double dependant town",
-          dependentAddressLocality: "my dependant town",
-          addressLocality: "my town",
-          postalCode: "myCode",
+  context("generateSearchResultString", () => {
+    it("should generate search result string with street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            streetName: "my inner street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1 My outter street my inner street, My double dependant town my dependant town my town, myCode",
         },
-        text: "My department My company Room 5 my building 1 My outer street my inner street, My double dependant town my dependant town my town, myCode",
-      },
-    ];
+      ];
 
-    data.forEach((addressData, index) => {
-      it(`should match test address ${index} to its expected text output`, () => {
-        const output = generateSearchResultString(addressData.address);
-        expect(output).to.equal(addressData.text);
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateSearchResultString(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
+      });
+    });
+
+    it("should generate search result string without street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1 My outter street, My double dependant town my dependant town my town, myCode",
+        },
+      ];
+
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateSearchResultString(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
       });
     });
   });
-
-  describe("generateHTMLofAddress", () => {
-    const data = [
-      {
-        address: {
-          organisationName: "My company",
-          departmentName: "My department",
-          buildingName: "my building",
-          subBuildingName: "Room 5",
-          buildingNumber: "1",
-          dependentStreetName: "My outer street",
-          streetName: "my inner street",
-          doubleDependentAddressLocality: "My double dependant town",
-          dependentAddressLocality: "my dependant town",
-          addressLocality: "my town",
-          postalCode: "myCode",
+  context("generateHTMLofAddress", () => {
+    it("should generate HTML with street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            streetName: "my inner street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
         },
-        text: "My department My company Room 5 my building 1<br>My outer street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
-      },
-    ];
+      ];
 
-    data.forEach((addressData, index) => {
-      it(`should match test address ${index} to its expected text output`, () => {
-        const output = generateHTMLofAddress(addressData.address);
-        expect(output).to.equal(addressData.text);
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateHTMLofAddress(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
+      });
+    });
+
+    it("should generate HTML without street name", () => {
+      const data = [
+        {
+          address: {
+            organisationName: "My company",
+            departmentName: "My deparment",
+            buildingName: "my building",
+            subBuildingName: "Room 5",
+            buildingNumber: "1",
+            dependentStreetName: "My outter street",
+            streetName: "my inner street",
+            doubleDependentAddressLocality: "My double dependant town",
+            dependentAddressLocality: "my dependant town",
+            addressLocality: "my town",
+            postalCode: "myCode",
+          },
+          text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+        },
+      ];
+
+      data.forEach((addressData, index) => {
+        it(`should match test address ${index} to its expected text output`, () => {
+          const output = generateHTMLofAddress(addressData.address);
+          expect(output).to.equal(addressData.text);
+        });
       });
     });
   });

--- a/test/browser/features/address-manual-empty-previous.feature
+++ b/test/browser/features/address-manual-empty-previous.feature
@@ -25,14 +25,6 @@ Feature: Happy Path - confirming manual address details - previous
       And they continue to confirm address
       Then they should see the confirm page
 
-    Scenario: Changing address values and unsuccessfully passing validation when the street is missing
-      Given they are on the address page
-      When they add their flat number "1"
-      And they add their house name "stratford house"
-      And they add their street ""
-      And they add their city "London"
-      And they continue to confirm address
-      Then they should see an error message on the address page "Enter your street name"
 
     Scenario: Changing address values and unsuccessfully passing validation when the town or city is missing
       Given they are on the address page

--- a/test/browser/features/address-manual-empty.feature
+++ b/test/browser/features/address-manual-empty.feature
@@ -20,14 +20,6 @@ Feature: Happy Path - confirming manual address details
       And they continue to confirm address
       Then they should see the confirm page
 
-    Scenario: Changing address values and unsuccessfully passing validation when the street is missing
-      Given they are on the address page
-      When they add their flat number "1"
-      And they add their house name "stratford house"
-      And they add their city "London"
-      And they add their residency date "2020"
-      And they continue to confirm address
-      Then they should see an error message on the address page "Enter your street name"
 
     Scenario: Changing address values and unsuccessfully passing validation when the town or city is missing
       Given they are on the address page


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Set the Street Name to optional on the address frontend screen. This will then allow the user to perform the address-cri journey without entering a street name. Thus the use case in which the user is staying on a location (such as a farm) without a street name will pass.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-991](https://govukverify.atlassian.net/browse/OJ-991)