### PR TITLE
OJ-989 Map flat number from API field subBuildingName

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "node src/app.js",
     "start:ci": "NODE_ENV=development API_BASE_URL=http://localhost:8010/ yarn dev",
+    "start:local:all": "NODE_ENV=development API_BASE_URL=http://localhost:8010/ npm-run-all -p -r mocks dev",
     "dev": "nodemon src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",

--- a/src/app/address/controllers/address/manual.js
+++ b/src/app/address/controllers/address/manual.js
@@ -13,7 +13,7 @@ class AddressController extends BaseController {
         address?.postalCode || req.sessionModel.get("addressPostcode");
 
       if (address) {
-        values.addressFlatNumber = address.addressFlatNumber;
+        values.addressFlatNumber = address.subBuildingName;
         values.addressHouseNumber = address.buildingNumber;
         values.addressHouseName = address.buildingName;
         values.addressStreetName = address.streetName;
@@ -88,7 +88,8 @@ class AddressController extends BaseController {
     }
 
     const address = {
-      buildingNumber: addressFlatNumber || addressHouseNumber,
+      subBuildingName: addressFlatNumber,
+      buildingNumber: addressHouseNumber,
       buildingName: addressHouseName,
       streetName: addressStreetName,
       addressLocality,
@@ -127,4 +128,5 @@ class AddressController extends BaseController {
     return hasChanged !== -1;
   }
 }
+
 module.exports = AddressController;

--- a/src/app/address/controllers/address/manual.test.js
+++ b/src/app/address/controllers/address/manual.test.js
@@ -76,8 +76,11 @@ describe("address controller", () => {
 
       const savedAddress = req.sessionModel.get("address");
       expect(next).to.have.been.calledOnce;
-      expect(savedAddress.buildingNumber).to.equal(
+      expect(savedAddress.subBuildingName).to.equal(
         addressToSave.addressFlatNumber
+      );
+      expect(savedAddress.buildingNumber).to.equal(
+        addressToSave.addressHouseNumber
       );
       expect(savedAddress.streetName).to.equal(addressToSave.addressStreetName);
       expect(savedAddress.addressLocality).to.equal(
@@ -133,8 +136,11 @@ describe("address controller", () => {
       expect(savedAddresses.buildingName).to.equal(
         addressToSave.addressHouseName
       );
-      expect(savedAddresses.buildingNumber).to.equal(
+      expect(savedAddresses.subBuildingName).to.equal(
         addressToSave.addressFlatNumber
+      );
+      expect(savedAddresses.buildingNumber).to.equal(
+        addressToSave.addressHouseNumber
       );
       expect(savedAddresses.addressLocality).to.equal(
         addressToSave.addressLocality

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -29,11 +29,11 @@ function extractAddressFields(address) {
   let localityNames = [];
 
   // handle building name
-  if (address.organisationName) {
-    buildingNames.push(address.organisationName);
-  }
   if (address.departmentName) {
     buildingNames.push(address.departmentName);
+  }
+  if (address.organisationName) {
+    buildingNames.push(address.organisationName);
   }
   if (address.subBuildingName) {
     buildingNames.push(address.subBuildingName);

--- a/src/presenters/addressPresenter.js
+++ b/src/presenters/addressPresenter.js
@@ -35,11 +35,11 @@ function extractAddressFields(address) {
   if (address.departmentName) {
     buildingNames.push(address.departmentName);
   }
-  if (address.buildingName) {
-    buildingNames.push(address.buildingName);
-  }
   if (address.subBuildingName) {
     buildingNames.push(address.subBuildingName);
+  }
+  if (address.buildingName) {
+    buildingNames.push(address.buildingName);
   }
   if (address.buildingNumber) {
     buildingNames.push(address.buildingNumber);

--- a/src/presenters/addressPresenter.test.js
+++ b/src/presenters/addressPresenter.test.js
@@ -10,18 +10,18 @@ describe("Address Presenter", () => {
       {
         address: {
           organisationName: "My company",
-          departmentName: "My deparment",
+          departmentName: "My department",
           buildingName: "my building",
           subBuildingName: "Room 5",
           buildingNumber: "1",
-          dependentStreetName: "My outter street",
+          dependentStreetName: "My outer street",
           streetName: "my inner street",
           doubleDependentAddressLocality: "My double dependant town",
           dependentAddressLocality: "my dependant town",
           addressLocality: "my town",
           postalCode: "myCode",
         },
-        text: "My company My deparment my building Room 5 1 My outter street my inner street, My double dependant town my dependant town my town, myCode",
+        text: "My company My department Room 5 my building 1 My outer street my inner street, My double dependant town my dependant town my town, myCode",
       },
     ];
 
@@ -38,18 +38,18 @@ describe("Address Presenter", () => {
       {
         address: {
           organisationName: "My company",
-          departmentName: "My deparment",
+          departmentName: "My department",
           buildingName: "my building",
           subBuildingName: "Room 5",
           buildingNumber: "1",
-          dependentStreetName: "My outter street",
+          dependentStreetName: "My outer street",
           streetName: "my inner street",
           doubleDependentAddressLocality: "My double dependant town",
           dependentAddressLocality: "my dependant town",
           addressLocality: "my town",
           postalCode: "myCode",
         },
-        text: "My company My deparment my building Room 5 1<br>My outter street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+        text: "My company My department Room 5 my building 1<br>My outer street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
       },
     ];
 

--- a/src/presenters/addressPresenter.test.js
+++ b/src/presenters/addressPresenter.test.js
@@ -21,7 +21,7 @@ describe("Address Presenter", () => {
           addressLocality: "my town",
           postalCode: "myCode",
         },
-        text: "My company My department Room 5 my building 1 My outer street my inner street, My double dependant town my dependant town my town, myCode",
+        text: "My department My company Room 5 my building 1 My outer street my inner street, My double dependant town my dependant town my town, myCode",
       },
     ];
 
@@ -49,7 +49,7 @@ describe("Address Presenter", () => {
           addressLocality: "my town",
           postalCode: "myCode",
         },
-        text: "My company My department Room 5 my building 1<br>My outer street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
+        text: "My department My company Room 5 my building 1<br>My outer street my inner street,<br>My double dependant town my dependant town my town,<br>myCode<br>",
       },
     ];
 

--- a/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
+++ b/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
@@ -1,0 +1,133 @@
+@mock-api:address-success @success
+Feature: compliance for address structures presented in https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0020-address-structure.md#4-examples-of-json
+
+  Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "ZZ1 1ZZ"
+
+  Scenario: Show sub building name as flat number
+    Then they should see the results page
+    And they have selected an address "FLAT 1 87 ZZZ WAY, WHITEHOUSE MILTON KEYNES, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with "FLAT 1"
+    And they should see house number prefilled with "87"
+    And they should see street prefilled with "ZZZ WAY"
+    And they should see town or city prefilled with "MILTON KEYNES"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "FLAT 1 87ZZZ WAY,"
+    And they should see the address value "WHITEHOUSE MILTON KEYNES,"
+    And they should see the address value "ZZ1 1ZZ"
+
+
+  Scenario: Show building name as house name
+    Then they should see the results page
+    And they have selected an address "FLAT 11 BLASHFORD ZZZ ROAD, LONDON, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with "FLAT 11"
+    And they should see house number prefilled with ""
+    And they should see house name prefilled with "BLASHFORD"
+    And they should see street prefilled with "ZZZ ROAD"
+    And they should see town or city prefilled with "LONDON"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "FLAT 11 BLASHFORDZZZ ROAD,"
+    And they should see the address value "LONDON,"
+    And they should see the address value "ZZ1 1ZZ"
+
+  Scenario: Show neither flat number nor house number
+    Then they should see the results page
+    And they have selected an address "ZZZ MARINA ZZZ ROAD, LONG ZZZ NOTTINGHAM, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with ""
+    And they should see house number prefilled with ""
+    And they should see house name prefilled with "ZZZ MARINA"
+    And they should see street prefilled with "ZZZ ROAD"
+    And they should see town or city prefilled with "NOTTINGHAM"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "ZZZ MARINA"
+    And they should see the address value "ZZZ ROAD,"
+    And they should see the address value "LONG ZZZ NOTTINGHAM,"
+    And they should see the address value "ZZ1 1ZZ"
+
+
+  Scenario: organisation name and dependent street name of a business is not editable
+    Then they should see the results page
+    And they have selected an address "ZZZ GROUP UNIT 2B ZZZ BUSINESS PARK 16 ZZZ PARK ZZZ STREET, SOME ZZZ LONG EATON GREAT MISSENDEN, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with "UNIT 2B"
+    And they should see house number prefilled with "16"
+    And they should see house name prefilled with "ZZZ BUSINESS PARK"
+    And they should see street prefilled with "ZZZ STREET"
+    And they should see town or city prefilled with "GREAT MISSENDEN"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "ZZZ GROUP UNIT 2B ZZZ BUSINESS PARK 16"
+    And they should see the address value "ZZZ PARK ZZZ STREET,"
+    And they should see the address value "SOME ZZZ LONG EATON GREAT MISSENDEN,"
+    And they should see the address value "ZZ1 1ZZ"
+
+  Scenario: no uprn is ok
+    Then they should see the results page
+    And they have selected an address "R103 ZZZ PARK CREEK ROAD, ZZZ ISLAND, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with ""
+    And they should see house number prefilled with ""
+    And they should see house name prefilled with "R103"
+    And they should see street prefilled with "CREEK ROAD"
+    And they should see town or city prefilled with "ZZZ ISLAND"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "R103"
+    And they should see the address value "ZZZ PARK CREEK ROAD,"
+    And they should see the address value "ZZZ ISLAND,"
+    And they should see the address value "ZZ1 1ZZ"
+
+  Scenario: dependent address locality is not editable
+    Then they should see the results page
+    And they have selected an address "13 ZZZ CRESCENT, NEW PITSLIGO FRASERBURGH, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with ""
+    And they should see house number prefilled with "13"
+    And they should see house name prefilled with ""
+    And they should see street prefilled with "ZZZ CRESCENT"
+    And they should see town or city prefilled with "FRASERBURGH"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "13"
+    And they should see the address value "ZZZ CRESCENT,"
+    And they should see the address value "NEW PITSLIGO FRASERBURGH,"
+    And they should see the address value "ZZ1 1ZZ"
+
+  Scenario: organisation name and dependent street name is not editable
+    Then they should see the results page
+    And they have selected an address "3 ZZZ WALK, MIDDLESBROUGH, ZZ1 1ZZ"
+    Then they should see the address page
+    And they should see the postcode prefilled with "ZZ1 1ZZ"
+    And they should see flat number prefilled with ""
+    And they should see house number prefilled with "3"
+    And they should see house name prefilled with ""
+    And they should see street prefilled with "ZZZ WALK"
+    And they should see town or city prefilled with "MIDDLESBROUGH"
+    When they add their residency date "current"
+    And they continue to confirm address
+    Then they should see the confirm page
+    And they should see the address value "3"
+    And they should see the address value "ZZZ WALK,"
+    And they should see the address value "MIDDLESBROUGH,"
+    And they should see the address value "ZZ1 1ZZ"
+

--- a/test/mocks/mappings/addresses.json
+++ b/test/mocks/mappings/addresses.json
@@ -34,6 +34,96 @@
       }
     },
     {
+      "scenarioName": "Compliance for addresses discussed at https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0020-address-structure.md",
+      "request": {
+        "method": "GET",
+        "urlPathPattern": "/postcode-lookup/ZZ1%201ZZ",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-success"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "uprn": "000",
+            "buildingName": "EAST ZZZ",
+            "addressLocality": "BEAMINSTER",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "uprn": "111",
+            "subBuildingName": "FLAT 1",
+            "buildingNumber": "87",
+            "streetName": "ZZZ WAY",
+            "dependentAddressLocality": "WHITEHOUSE",
+            "addressLocality": "MILTON KEYNES",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "subBuildingName": "FLAT 11",
+            "buildingName": "BLASHFORD",
+            "streetName": "ZZZ ROAD",
+            "addressLocality": "LONDON",
+            "postalCode": "ZZ1 1ZZ"
+          },
+          {
+            "uprn": "222",
+            "buildingName": "ZZZ MARINA",
+            "streetName": "ZZZ ROAD",
+            "dependentAddressLocality": "LONG ZZZ",
+            "addressLocality": "NOTTINGHAM",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "uprn": "333",
+            "organisationName": "ZZZ GROUP",
+            "subBuildingName": "UNIT 2B",
+            "buildingNumber": "16",
+            "buildingName": "ZZZ BUSINESS PARK",
+            "dependentStreetName": "ZZZ PARK",
+            "streetName": "ZZZ STREET",
+            "doubleDependentAddressLocality": "SOME ZZZ",
+            "dependentAddressLocality": "LONG EATON",
+            "addressLocality": "GREAT MISSENDEN",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "buildingName": "R103",
+            "dependentStreetName": "ZZZ PARK",
+            "streetName": "CREEK ROAD",
+            "doubleDependentAddressLocality": "",
+            "addressLocality": "ZZZ ISLAND",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "uprn": "444",
+            "buildingNumber": "13",
+            "streetName": "ZZZ CRESCENT",
+            "dependentAddressLocality": "NEW PITSLIGO",
+            "addressLocality": "FRASERBURGH",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          },
+          {
+            "uprn": "555",
+            "buildingNumber": "3",
+            "streetName": "ZZZ WALK",
+            "addressLocality": "MIDDLESBROUGH",
+            "postalCode": "ZZ1 1ZZ",
+            "addressCountry": "GB"
+          }
+        ]
+      }
+    },
+    {
       "scenarioName": "Address",
       "requiredScenarioState": "AddressResponses",
       "newScenarioState": "AddressResponses",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

✅ Ensure that flat number is displayed and is editable in Address CRI
<img width="100" alt="Screenshot 2022-10-23 at 17 42 32" src="https://user-images.githubusercontent.com/137389/197404610-939cd6b9-0616-42e8-82fc-d79f6284a34c.png">

✅ Fix incorrect mapping and ordering of some fields when displaying an address
<img width="100" alt="Screenshot 2022-10-23 at 17 42 56" src="https://user-images.githubusercontent.com/137389/197404659-915a356e-837e-465d-ba8b-5eaaeb95826b.png">

✅ Check that we don't break anything by checking the addresses mentioned in [RFC 0020 Address Structure](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0020-address-structure.md#4-examples-of-json) display correctly.

To test yourself, please first merge https://github.com/alphagov/di-ipv-cri-address-front/pull/429, then:

* run `yarn install`
* run `yarn start:local:all`
* visit http://localhost:5010
* use postcode `ZZ1 1ZZ`
* choose the `MILTON KEYNES` address
* note that the flat number is displayed on edit and on the confirm page
* note that you can test the addresses mentioned in [RFC 0020 Address Structure](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0020-address-structure.md#4-examples-of-json) by using the postcode `ZZ1 1ZZ`


### What changed

* [chore: start address frontend attached to mock of Ordnance Survey](https://github.com/alphagov/di-ipv-cri-address-front/pull/428/commits/541c7e9cc31fb5b81b921524aa0515325f810c31)
* [fix: map subBuildingName from api to address field addressFlatNumber](https://github.com/alphagov/di-ipv-cri-address-front/pull/428/commits/6d9c7cf9999ee936a67da79b28aaaf333b1ce2f8)
* [fix: subBuildingName to precede buildingName for presentation](https://github.com/alphagov/di-ipv-cri-address-front/pull/428/commits/dc017334e9a1ddc81dc360b34ceb9f8b2165e31b)
* [fix: department name to precede organisation name for presentation](https://github.com/alphagov/di-ipv-cri-address-front/pull/428/commits/3f850ddcc2e0e0906769035ad81e4828991828f1)
* [test: browser tests to cover the display of flat name in manual addre…](https://github.com/alphagov/di-ipv-cri-address-front/pull/428/commits/a28012144e46ea516a5437bb25dc34198d3fa4d9)

### Why did it change

Fix defects reported by users.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-989](https://govukverify.atlassian.net/browse/OJ-989)

## Checklists


### Other considerations

- [ ] See adjacent PR https://github.com/alphagov/di-ipv-cri-address-front/pull/429 that tidies up some documentation and makes this PR easier to check out.
