### PR TITLE
OJ-1012 Address frontend alarms

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -519,6 +519,7 @@ Resources:
   AddressNoTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: !Sub Address ${Environment} frontend no ECS service tasks
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -540,6 +541,7 @@ Resources:
   AddressOnlyOneTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: !Sub Address ${Environment} frontend below desired ECS service tasks
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -561,6 +563,7 @@ Resources:
   Address5XXOnELB:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: !Sub Address ${Environment} frontend 5XX count
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -558,6 +558,29 @@ Resources:
       ComparisonOperator: LessThanThreshold
       TreatMissingData: notBreaching
 
+  Address5XXOnELB:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref LoadBalancerListenerTargetGroupECS
+        - Name: LoadBalancer
+          Value: !Ref LoadBalancer
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
 # Outputs
 
 Outputs:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -516,6 +516,27 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
+  AddressNoTaskCountAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: TaskCount
+      Namespace: ECS/ContainerInsights
+      Statistic: Average
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref AddressFrontEcsCluster
+      Period: 60
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+
 # Outputs
 
 Outputs:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -537,6 +537,27 @@ Resources:
       ComparisonOperator: LessThanThreshold
       TreatMissingData: notBreaching
 
+  AddressOnlyOneTaskCountAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue core-infrastructure-AlarmTopic
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: TaskCount
+      Namespace: ECS/ContainerInsights
+      Statistic: Average
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref AddressFrontEcsCluster
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      Threshold: 2
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: notBreaching
+
 # Outputs
 
 Outputs:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -536,7 +536,7 @@ Resources:
       DatapointsToAlarm: 2
       Threshold: 1
       ComparisonOperator: LessThanThreshold
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
 
   AddressOnlyOneTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -558,7 +558,7 @@ Resources:
       DatapointsToAlarm: 3
       Threshold: 2
       ComparisonOperator: LessThanThreshold
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
 
   Address5XXOnELB:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Three CloudWatch alarms for the Address CRI frontend hosted on ECS. Alarm when:
1. ECS tasks lower than 1 over 2 minutes - there are no tasks running
2. ECS tasks lower than 2 over 15 minutes - there should be two tasks running
3. More than 1 ELB 5XX error every minute over 5 minutes 


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1012](https://govukverify.atlassian.net/browse/OJ-1012)
