### PR TITLE
OJ-1015 - remove old log group subscription filter

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -253,14 +253,6 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-AddressFront-ECS
       RetentionInDays: 14
 
-  ECSAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref ECSAccessLogsGroup
-
   ECSAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
@@ -440,14 +432,6 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-AddressFront-API-GW-AccessLogs
-
-  APIGWAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Ref APIGWAccessLogsGroup
 
   APIGWAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
### What changed
Removed old log group subscription filters.

### Why did it change
As requested by @instantiator


### Issue tracking


- [OJ-1015](https://govukverify.atlassian.net/browse/OJ-1015)
