### PR TITLE
OJ-1006 testing flat number on edit

### DIFF
--- a/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
+++ b/test/browser/features/address-manual-rfc-0020-address-structure-compliance.feature
@@ -37,7 +37,7 @@ Feature: compliance for address structures presented in https://github.com/alpha
     When they add their residency date "current"
     And they continue to confirm address
     Then they should see the confirm page
-    And they should see the address value "FLAT 11 BLASHFORDZZZ ROAD,"
+    And they should see the address value "FLAT 11 BLASHFORD<br>ZZZ ROAD"
     And they should see the address value "LONDON,"
     And they should see the address value "ZZ1 1ZZ"
 

--- a/test/browser/features/flat-number.feature
+++ b/test/browser/features/flat-number.feature
@@ -1,10 +1,42 @@
+@mock-api:address-success @success
 Feature: Confirming flat number is displayed correctly after manual entry
 
     Feature Description: User is asked to enter their address manually if the system does not recognise their postcode. User enters their address including Flat Number manually.
 
+Background:
+    Given Authenticalable Address Amy is using the system
+    And they have started the address journey
+    And they searched for their postcode "E1 8QS"
+    Then they should see the results page
+    When they have selected Cant find address
+
     Scenario: Testing flat number on edit
-        Given user is on Address CRI Build Environment
-        When user enters their postcode and click Find address
-        And user clicks I cannot find my address in the list
-        When user enters their flat number manually
-        Then the flat number is displayed correctly
+      Given they are on the address page
+      When they add their flat number "17"
+      And they add their house number "115"
+      And they add their street "Downing Street"
+      And they add their city "London"
+      And they add their residency date "2014"
+      And they continue to confirm address
+      Then they should see the address value "17<br>115 Downing Street,<br>"
+
+    Scenario: Testing flat number on edit
+      Given they are on the address page
+      When they add their flat number "17"
+      And they add their house name "house"
+      And they add their street "Downing Street"
+      And they add their city "London"
+      And they add their residency date "2014"
+      And they continue to confirm address
+      Then they should see the address value "17 house<br>Downing Street,<br>"
+
+    Scenario: Testing flat number on edit
+      Given they are on the address page
+      When they add their flat number "17"
+      And they add their house name "house"
+      And they add their house number "115"
+      And they add their street "Downing Street"
+      And they add their city "London"
+      And they add their residency date "2014"
+      And they continue to confirm address
+      Then they should see the address value "17 house<br>115 Downing Street,<br>"

--- a/test/browser/features/flat-number.feature
+++ b/test/browser/features/flat-number.feature
@@ -1,0 +1,10 @@
+Feature: Confirming flat number is displayed correctly after manual entry
+
+    Feature Description: User is asked to enter their address manually if the system does not recognise their postcode. User enters their address including Flat Number manually.
+
+    Scenario: Testing flat number on edit
+        Given user is on Address CRI Build Environment
+        When user enters their postcode and click Find address
+        And user clicks I cannot find my address in the list
+        When user enters their flat number manually
+        Then the flat number is displayed correctly

--- a/test/browser/features/flat-number.feature
+++ b/test/browser/features/flat-number.feature
@@ -10,7 +10,7 @@ Background:
     Then they should see the results page
     When they have selected Cant find address
 
-    Scenario: Testing flat number on edit
+    Scenario: Testing flat number on edit. Adding flat number and house number
       Given they are on the address page
       When they add their flat number "17"
       And they add their house number "115"
@@ -20,7 +20,7 @@ Background:
       And they continue to confirm address
       Then they should see the address value "17<br>115 Downing Street,<br>"
 
-    Scenario: Testing flat number on edit
+    Scenario: Testing flat number on edit. Adding flat number and house name
       Given they are on the address page
       When they add their flat number "17"
       And they add their house name "house"
@@ -30,7 +30,7 @@ Background:
       And they continue to confirm address
       Then they should see the address value "17 house<br>Downing Street,<br>"
 
-    Scenario: Testing flat number on edit
+    Scenario: Testing flat number on edit. Adding flat number, house name and house number
       Given they are on the address page
       When they add their flat number "17"
       And they add their house name "house"

--- a/test/browser/pages/confirm.js
+++ b/test/browser/pages/confirm.js
@@ -45,7 +45,7 @@ module.exports = class PlaywrightDevPage {
   }
 
   returnCurrentAddress() {
-    return this.page.textContent(
+    return this.page.innerHTML(
       "#main-content > div > div > dl > div:nth-child(1) > dd.govuk-summary-list__value"
     );
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Adding browser tests.
Minor change to how we get the confirmed details address. We changed it to inner html so that we can confirm the order of the address output is how we expect.

For example previously we would get the following value from playwright.
`1 115myroad mylocation`
now
`1 <br>my road<br> my location`

This means we can different styles of addresses outputs.

### Why did it change

Adding browser tests for Address flat number change - https://govukverify.atlassian.net/browse/OJ-989

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1006](https://govukverify.atlassian.net/browse/OJ-1006)
