### PR TITLE
Oj 941/build UI for partial address

### DIFF
--- a/src/app/address/controllers/address/prepopulate.js
+++ b/src/app/address/controllers/address/prepopulate.js
@@ -16,9 +16,15 @@ class AddressPrepopulateController extends BaseController {
         },
       });
 
-      console.log(prepopulatedAddresses.data);
+      if (prepopulatedAddresses?.data?.length > 0) {
+        req.session.prepopulatedPostcode = true;
+        req.sessionModel.set(
+          "addressSearch",
+          prepopulatedAddresses.data[0].postalCode
+        );
+      }
 
-      super.saveValues(req, res, () => {
+      return super.saveValues(req, res, () => {
         callback();
       });
     } catch (err) {

--- a/src/app/address/controllers/address/prepopulate.js
+++ b/src/app/address/controllers/address/prepopulate.js
@@ -8,6 +8,8 @@ const {
 
 class AddressPrepopulateController extends BaseController {
   async saveValues(req, res, callback) {
+    req.session.prepopulatedPostcode = false;
+
     try {
       const prepopulatedAddresses = await req.axios.get(`${GET_ADDRESSES}`, {
         headers: {

--- a/src/app/address/controllers/address/prepopulate.js
+++ b/src/app/address/controllers/address/prepopulate.js
@@ -9,12 +9,14 @@ const {
 class AddressPrepopulateController extends BaseController {
   async saveValues(req, res, callback) {
     try {
-      await req.axios.get(`${GET_ADDRESSES}`, {
+      const prepopulatedAddresses = await req.axios.get(`${GET_ADDRESSES}`, {
         headers: {
           session_id: req.session.tokenId,
           "session-id": req.session.tokenId,
         },
       });
+
+      console.log(prepopulatedAddresses.data);
 
       super.saveValues(req, res, () => {
         callback();

--- a/src/app/address/controllers/address/prepopulate.test.js
+++ b/src/app/address/controllers/address/prepopulate.test.js
@@ -62,12 +62,6 @@ describe("Prepopulate controller", () => {
         prototypeSpy.restore();
       });
 
-      it("should call super.saveValues", async () => {
-        await prepopulateController.saveValues(req, res, next);
-
-        expect(prototypeSpy).to.have.been.calledWith(req, res);
-      });
-
       describe("with empty addresses", () => {
         beforeEach(async () => {
           req.axios.get = sinon.fake.resolves([]);
@@ -75,16 +69,38 @@ describe("Prepopulate controller", () => {
           await prepopulateController.saveValues(req, res, next);
         });
 
-        it("should set addressPostcode using first postcode in results", () => {
+        it("should set not addressPostcode", () => {
           expect(req.sessionModel.get("addressSearch")).to.be.undefined;
         });
+
+        it("should set prepopulatedPostcode to be false", () => {
+          expect(req.session.prepopulatedPostcode).to.be.false;
+        });
+
+        it("should call callback", async () => {
+          expect(next).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe("with addresses", () => {
+      beforeEach(async () => {
+        req.axios.get = sinon.fake.resolves({
+          data: [{ postalCode: "Q1 1AB" }],
+        });
+
+        await prepopulateController.saveValues(req, res, next);
+      });
+
+      it("should set prepopulatedPostcode to be true", () => {
+        expect(req.session.prepopulatedPostcode).to.be.true;
+      });
+
+      it("should set addressPostcode using first postcode in results", () => {
+        expect(req.sessionModel.get("addressSearch")).to.equal("Q1 1AB");
       });
 
       it("should call callback", async () => {
-        req.axios.get = sinon.fake.resolves([]);
-
-        await prepopulateController.saveValues(req, res, next);
-
         expect(next).to.have.been.calledOnce;
       });
     });

--- a/src/app/address/controllers/address/search.js
+++ b/src/app/address/controllers/address/search.js
@@ -7,8 +7,18 @@ const {
 } = require("../../../../lib/config");
 
 class AddressSearchController extends BaseController {
+  locals(req, res) {
+    res.locals.prepopulatedPostcode = req.session.prepopulatedPostcode;
+
+    return super.locals(req, res);
+  }
+
   async saveValues(req, res, callback) {
+    req.session.prepopulatedPostcode = false;
+
     const addressPostcode = req.body["addressSearch"];
+
+    req.sessionModel.set("addressSearch", addressPostcode);
 
     try {
       const addressPostcode = req.body["addressSearch"];

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -11,6 +11,7 @@ done:
   title: "Wedi'i wneud"
 addressSearch:
   title: "Darganfyddwch eich cyfeiriad"
+  drivingLicence: "Rydym wedi dod o hyd i'r cod post canlynol ar eich trwydded yrru."
 address-previous-search:
   title: "Darganfyddwch eich cyfeiriad blaenorol"
 address-results:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -15,6 +15,7 @@ done:
 
 addressSearch:
   title: Find your address
+  drivingLicence: We found the following postcode on your driving licence.
 
 address-previous-search:
   title: Find your previous address

--- a/src/views/address/search.html
+++ b/src/views/address/search.html
@@ -12,6 +12,14 @@
   <h1 id="header" class="govuk-heading-l">{{translate("pages.addressSearch.title")}} </h1>
   {% call hmpoForm(ctx) %}
 
+{% if prepopulatedPostcode %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText({
+  text: translate("pages.addressSearch.drivingLicence")
+}) }}
+{% endif %}
+
     {{ hmpoText(ctx, {
       id: "addressSearch",
       label: {

--- a/test/browser/features/address-with-prepopulated-postcode.feature
+++ b/test/browser/features/address-with-prepopulated-postcode.feature
@@ -1,19 +1,28 @@
-@mock-api:address-prepopulated-postcode
 Feature: Prepopulated Address
 
-  @only
+  @mock-api:address-prepopulated-postcode
   Scenario: Showing prepopulated postcode
     Given Prepopulated Patrick is using the system
     When they have started the address journey
-    Then they should see the postcode prefilled with "E1 8QS"
-#    And they searched for their postcode "E1 8QS"
-#    Then they should see the results page
+    Then they should see the search postcode prefilled with "E1 8QS"
+    And the driving licence callout should be visible
 
-#  @mock-api:address
-#  Scenario: Showing non-prepopulated postcode
-#    Given Unpopulated Una is using the system
-#    When they have started the address journey
-#    Then they should not see the postcode prefilled
+
+  @mock-api:address-prepopulated-postcode @only
+  Scenario: Showing prepopulated postcode
+    Given Prepopulated Patrick is using the system
+    And they have started the address journey
+    And they searched for their postcode "SW1A 1AA"
+    When they choose go back to search
+    Then they should see the search postcode prefilled with "SW1A 1AA"
+    And the driving licence callout should not be visible
+#
+  @mock-api:address-success
+  Scenario: Showing non-prepopulated postcode
+    Given Unpopulated Una is using the system
+    When they have started the address journey
+    Then they should not see the search postcode prefilled
+    And the driving licence callout should not be visible
 
 #  Scenario: Prepopulated error
 #    Given Prepopulated Error Penny is using the system

--- a/test/browser/features/address-with-prepopulated-postcode.feature
+++ b/test/browser/features/address-with-prepopulated-postcode.feature
@@ -1,0 +1,21 @@
+@mock-api:address-prepopulated-postcode
+Feature: Prepopulated Address
+
+  @only
+  Scenario: Showing prepopulated postcode
+    Given Prepopulated Patrick is using the system
+    When they have started the address journey
+    Then they should see the postcode prefilled with "E1 8QS"
+#    And they searched for their postcode "E1 8QS"
+#    Then they should see the results page
+
+#  @mock-api:address
+#  Scenario: Showing non-prepopulated postcode
+#    Given Unpopulated Una is using the system
+#    When they have started the address journey
+#    Then they should not see the postcode prefilled
+
+#  Scenario: Prepopulated error
+#    Given Prepopulated Error Penny is using the system
+#    When they have started the address journey
+#    Then they should not see the postcode prefilled

--- a/test/browser/pages/search.js
+++ b/test/browser/pages/search.js
@@ -12,6 +12,10 @@ module.exports = class PlaywrightDevPage {
     return await this.page.textContent("#header");
   }
 
+  async getPostcode() {
+    return this.page.inputValue("#addressSearch");
+  }
+
   async searchPostcode(postcode = "TE5T1NG") {
     await this.page.fill(".govuk-input", postcode);
     await this.page.click("#continue");
@@ -28,5 +32,9 @@ module.exports = class PlaywrightDevPage {
 
   getErrorSummary() {
     return this.page.textContent(".govuk-error-summary");
+  }
+
+  async drivingLicenceCalloutIsVisible() {
+    return this.page.locator(".govuk-inset-text").isVisible();
   }
 };

--- a/test/browser/step_definitions/search.js
+++ b/test/browser/step_definitions/search.js
@@ -39,3 +39,31 @@ Then("they should see the search page content in English", async function () {
   const searchPage = new SearchPage(this.page);
   expect(await searchPage.getPageTitle()).to.include("Find your address");
 });
+
+Then(
+  "they should see the search postcode prefilled with {string}",
+  async function (value) {
+    const searchPage = new SearchPage(this.page);
+    const input = await searchPage.getPostcode();
+
+    expect(input).to.equal(value);
+  }
+);
+
+Then("they should not see the search postcode prefilled", async function () {
+  const searchPage = new SearchPage(this.page);
+  const input = await searchPage.getPostcode();
+
+  expect(input).to.equal("");
+});
+
+Then(
+  /^the driving licence callout should (not ){0,1}be visible$/,
+  async function (visibleAsString) {
+    const visible = visibleAsString !== "not ";
+
+    const searchPage = new SearchPage(this.page);
+
+    expect(await searchPage.drivingLicenceCalloutIsVisible()).to.equal(visible);
+  }
+);

--- a/test/browser/support/setup.js
+++ b/test/browser/support/setup.js
@@ -44,7 +44,16 @@ Before(async function ({ pickle } = {}) {
 
   this.SCENARIO_ID_HEADER = header;
 
-  await axios.get(`${process.env.API_BASE_URL}/__reset/${header}`);
+  try {
+    await axios.get(`${process.env.API_BASE_URL}/__reset/${header}`);
+  } catch (e) {
+    /* eslint-disable no-console */
+    console.log("Error resetting mock");
+    console.log(`${process.env.API_BASE_URL}/__reset/${header}`);
+    console.log(e.message);
+    /* eslint-enable no-console */
+    throw e;
+  }
 });
 
 // Create a new test context and page per scenario

--- a/test/mocks/mappings/pre-populated-postcode.json
+++ b/test/mocks/mappings/pre-populated-postcode.json
@@ -1,0 +1,73 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Address Prepopulated Postcode",
+      "newScenarioState": "Started",
+      "request": {
+        "method": "GET",
+        "url": "/__reset/address-prepopulated-postcode"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "scenarioName": "Address Prepopulated Postcode",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "Addresses",
+      "request": {
+        "method": "POST",
+        "urlPath": "/session",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-prepopulated-postcode"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "request": "${json-unit.any-string}",
+              "client_id": "${json-unit.any-string}"
+            },
+            "ignoreArrayOrder": true
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "session_id": "ABADCAFE",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net/return"
+        }
+      }
+    },
+    {
+      "scenarioName": "Address Prepopulated Postcode",
+      "requiredScenarioState": "Addresses",
+      "request": {
+        "method": "GET",
+        "urlPath": "/addresses",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "address-prepopulated-postcode"
+          },
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "postalCode": "E1 8QS"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add prepopulated address to address lookup screen.

Driving licence callout should only be present until the user moves off the address search screen. After that, the postcode is considered to have been entered by the user.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-941](https://govukverify.atlassian.net/browse/OJ-941)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
