### PR TITLE
OJ-1146 update pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: "detect-secrets --all-files"


### PR DESCRIPTION
## Proposed changes

### What changed

pre-commit workflow updated to specify python version

### Why did it change

To get rid or the annoying warning and to ensure no breakage if the runners update to a different version 

### Issue tracking

- [OJ-1146](https://govukverify.atlassian.net/browse/OJ-1146)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1146]: https://govukverify.atlassian.net/browse/OJ-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ