### PR TITLE
oj-1103 address front exported load balancer arn

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -479,7 +479,6 @@ Resources:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
         TargetValue: 70.0
 
-
   AddressFrontSessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -568,8 +567,6 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
-# Outputs
-
 Outputs:
   StackName:
     Description: "CloudFormation stack name"
@@ -583,3 +580,8 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-AddressFrontGatewayId"
     Value: !Ref ApiGwHttpEndpoint
+  AddressLoadBalancerArn:
+    Description: The Fargate Front End Load Balancer ARN
+    Export:
+      Name: !Sub "${AWS::StackName}-LoadBalancer"
+    Value: !Ref LoadBalancer


### PR DESCRIPTION
## Proposed changes

### What changed

Added export of the load balancer ARN

### Why did it change

This allows the WAF pipeline deployment to reference the load balancer ARN for the web ACL association for the front end

### Issue tracking

- [OJ-1103](https://govukverify.atlassian.net/browse/OJ-1103)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1103]: https://govukverify.atlassian.net/browse/OJ-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ