### PR TITLE
fix: Update tests with year of 2023

### DIFF
--- a/test/browser/features/address-confirm.feature
+++ b/test/browser/features/address-confirm.feature
@@ -12,7 +12,7 @@ Feature: Happy Path - confirming address details
 
     Scenario: Adding an year date that should show the previous address modal
       Given they are on the address page
-      When they add their residency date "2022"
+      When they add their residency date "2023"
       And they continue to confirm address
       Then they should see the confirm page
       And they should see the previous address modal
@@ -25,7 +25,7 @@ Feature: Happy Path - confirming address details
 
     Scenario: Not selecting a radio button should show a validation message
       Given they are on the address page
-      When they add their residency date "2022"
+      When they add their residency date "2023"
       And they continue to confirm address
       Then they should see the confirm page
       And they should see the previous address modal
@@ -34,7 +34,7 @@ Feature: Happy Path - confirming address details
 
     Scenario: Selecting less than 3 months residence should move the user to the previous address journey
       Given they are on the address page
-      When they add their residency date "2022"
+      When they add their residency date "2023"
       And they continue to confirm address
       Then they should see the confirm page
       And they should see the previous address modal

--- a/test/browser/features/address-manual-empty-previous.feature
+++ b/test/browser/features/address-manual-empty-previous.feature
@@ -7,7 +7,7 @@ Feature: Happy Path - confirming manual address details - previous
     And they have started the address journey
     And they searched for their postcode "E1 8QS"
     Then they have selected an address ""
-    When they add their residency date "2022"
+    When they add their residency date "2023"
     And they continue to confirm address
     And they select the less than three months radio button
     And they confirm their details

--- a/test/browser/features/address-manual-preselected-previous.feature
+++ b/test/browser/features/address-manual-preselected-previous.feature
@@ -7,7 +7,7 @@ Feature: Happy Path - confirming preselected address details and date invalidati
     And they have started the address journey
     And they searched for their postcode "E1 8QS"
     Then they have selected an address ""
-    When they add their residency date "2022"
+    When they add their residency date "2023"
     And they continue to confirm address
     And they select the less than three months radio button
     And they confirm their details

--- a/test/browser/features/address-results-previous.feature
+++ b/test/browser/features/address-results-previous.feature
@@ -7,7 +7,7 @@ Feature: Happy Path - confirming preselected address details and date invalidati
     And they have started the address journey
     And they searched for their postcode "E1 8QS"
     Then they have selected an address ""
-    When they add their residency date "2022"
+    When they add their residency date "2023"
     And they continue to confirm address
     And they select the less than three months radio button
     And they confirm their details

--- a/test/browser/features/address-search-previous.feature
+++ b/test/browser/features/address-search-previous.feature
@@ -7,7 +7,7 @@ Feature: Happy Path - previous
       And they have started the address journey
       And they searched for their postcode "E1 8QS"
       Then they have selected an address "10 WHITECHAPEL HIGH STREET, LONDON, E1 8QS"
-      When they add their residency date "2022"
+      When they add their residency date "2023"
       And they continue to confirm address
       And they select the less than three months radio button
       And they confirm their details


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Shift test to using 2023 instead of 2022

<!-- Describe the changes in detail - the "what"-->

### Why did it change

We have a 3-month window for calculating showing the previous address screen. 1 April is 3 months after 1 January, so tests started failing.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
